### PR TITLE
headers cleaned up: 

### DIFF
--- a/Gorm.m
+++ b/Gorm.m
@@ -25,17 +25,10 @@
  */
 
 
-#include <GormCore/GormGenericEditor.h>
-#include <GormCore/GormPrivate.h>
-#include <GormCore/GormFontViewController.h>
-#include <GormCore/GormSetNameController.h>
-#include <GormCore/GormFunctions.h>
-#include <GormCore/GormPluginManager.h>
-#include <GormCore/GormDocumentController.h>
-#include <GormCore/GormServer.h>
+#include <GormCore/GormCore.h>
+#include <GormPrefs/GormPrefs.h>
 
 #include <GNUstepBase/GSObjCRuntime.h>
-#include <GormPrefs/GormPrefController.h>
 
 @interface Gorm : NSApplication <IB, Gorm>
 {

--- a/GormCore/GNUmakefile
+++ b/GormCore/GNUmakefile
@@ -39,6 +39,7 @@ srcdir = .
 include ../Version
 
 GormCore_HEADER_FILES = \
+	GormCore.h \
 	GormBoxEditor.h \
 	GormClassEditor.h \
 	GormClassInspector.h \

--- a/GormCore/GormBoxEditor.m
+++ b/GormCore/GormBoxEditor.m
@@ -22,8 +22,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <InterfaceBuilder/IBObjectAdditions.h>
 #include <AppKit/AppKit.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 #include "GormPrivate.h"
 #include "GormBoxEditor.h"

--- a/GormCore/GormClassEditor.h
+++ b/GormCore/GormClassEditor.h
@@ -25,8 +25,10 @@
 #ifndef INCLUDED_GormClassEditor_h
 #define INCLUDED_GormClassEditor_h
 
+#include <AppKit/AppKit.h>
+
 #include <InterfaceBuilder/InterfaceBuilder.h>
-#include <AppKit/NSBox.h>
+
 #include <GormCore/GormOutlineView.h>
 
 @class NSString, NSArray, GormDocument, GormClassManager, NSBrowser;

--- a/GormCore/GormClassEditor.m
+++ b/GormCore/GormClassEditor.m
@@ -25,6 +25,7 @@
 
 #include <Foundation/Foundation.h>
 #include <AppKit/AppKit.h>
+
 #include "GormClassEditor.h"
 #include "GormClassManager.h"
 #include "GormFunctions.h"

--- a/GormCore/GormClassInspector.h
+++ b/GormCore/GormClassInspector.h
@@ -27,7 +27,8 @@
 /* All Rights reserved */
 
 #include <AppKit/AppKit.h>
-#include <InterfaceBuilder/IBInspector.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class GormClassManager;
 

--- a/GormCore/GormClassInspector.m
+++ b/GormCore/GormClassInspector.m
@@ -27,13 +27,15 @@
 /* All Rights reserved */
 
 #include <AppKit/AppKit.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
+
 #include "GormClassInspector.h"
 #include "GormClassManager.h"
 #include "GormDocument.h"
 #include "GormFunctions.h"
 #include "GormPrivate.h"
 #include "GormProtocol.h"
-#include <InterfaceBuilder/IBApplicationAdditions.h>
 
 NSNotificationCenter *nc = nil;
 

--- a/GormCore/GormClassManager.h
+++ b/GormCore/GormClassManager.h
@@ -23,7 +23,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <InterfaceBuilder/IBPalette.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 #ifndef INCLUDED_GormClassManager_h
 #define INCLUDED_GormClassManager_h

--- a/GormCore/GormClassManager.m
+++ b/GormCore/GormClassManager.m
@@ -23,20 +23,16 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
+#include <Foundation/Foundation.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
+#include <GormObjCHeaderParser/GormObjCHeaderParser.h>
+
 #include "GormPrivate.h"
 #include "GormCustomView.h"
 #include "GormDocument.h"
 #include "GormFilesOwner.h"
 #include "GormPalettesManager.h"
-#include <InterfaceBuilder/IBEditors.h>
-#include <InterfaceBuilder/IBPalette.h>
-#include <Foundation/NSValue.h>
-#include <Foundation/NSException.h>
-
-#include <GormObjCHeaderParser/OCHeaderParser.h>
-#include <GormObjCHeaderParser/OCClass.h>
-#include <GormObjCHeaderParser/OCMethod.h>
-#include <GormObjCHeaderParser/OCIVar.h>
 
 /**
  * Just a few definitions to start things out.  To increase efficiency,

--- a/GormCore/GormClassPanelController.m
+++ b/GormCore/GormClassPanelController.m
@@ -25,6 +25,7 @@
 /* All Rights reserved */
 
 #include <AppKit/AppKit.h>
+
 #include "GormClassPanelController.h"
 #include "GormPrivate.h"
 

--- a/GormCore/GormConnectionInspector.h
+++ b/GormCore/GormConnectionInspector.h
@@ -27,8 +27,9 @@
 #ifndef INCLUDED_GormConnectionInspector_h
 #define INCLUDED_GormConnectionInspector_h
 
-#include <AppKit/NSNibConnector.h>
-#include <InterfaceBuilder/IBInspector.h>
+#include <AppKit/AppKit.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSBrowser, NSArray, NSMutableArray;
 

--- a/GormCore/GormConnectionInspector.m
+++ b/GormCore/GormConnectionInspector.m
@@ -24,8 +24,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <AppKit/NSNibConnector.h>
-#include <InterfaceBuilder/IBInspector.h>
+#include <AppKit/AppKit.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 #include "GormPrivate.h"
 #include "GormConnectionInspector.h"

--- a/GormCore/GormControlEditor.m
+++ b/GormCore/GormControlEditor.m
@@ -22,9 +22,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <InterfaceBuilder/IBObjectAdditions.h>
+#include <Foundation/Foundation.h>
 #include <AppKit/AppKit.h>
-#include <Foundation/NSArchiver.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 #include "GormPrivate.h"
 #include "GormViewWithSubviewsEditor.h"

--- a/GormCore/GormCore.h
+++ b/GormCore/GormCore.h
@@ -1,0 +1,104 @@
+/* GormCore.h
+*
+* Copyright (C) 2019 Free Software Foundation, Inc.
+*
+* Author:  Lars Sonchocky-Helldorf
+* Date:  01.11.19
+*
+* This file is part of GNUstep.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published by
+* the Free Software Foundation; either version 2.1 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
+*/
+
+#import <Foundation/Foundation.h>
+
+#ifndef GNUSTEP
+//! Project version number for GormCore.
+FOUNDATION_EXPORT double GormCoreVersionNumber;
+
+//! Project version string for GormCore.
+FOUNDATION_EXPORT const unsigned char GormCoreVersionString[];
+#endif
+
+#ifndef INCLUDED_GORMCORE_H
+#define INCLUDED_GORMCORE_H
+ 
+#include <GormCore/GormBoxEditor.h>
+#include <GormCore/GormClassEditor.h>
+#include <GormCore/GormClassInspector.h>
+#include <GormCore/GormClassManager.h>
+#include <GormCore/GormClassPanelController.h>
+#include <GormCore/GormConnectionInspector.h>
+#include <GormCore/GormControlEditor.h>
+#include <GormCore/GormCustomClassInspector.h>
+#include <GormCore/GormCustomView.h>
+#include <GormCore/GormDefines.h>
+#include <GormCore/GormDocument.h>
+#include <GormCore/GormDocumentController.h>
+#include <GormCore/GormDocumentWindow.h>
+#include <GormCore/GormFilePrefsManager.h>
+#include <GormCore/GormFilesOwner.h>
+#include <GormCore/GormFontViewController.h>
+#include <GormCore/GormFunctions.h>
+#include <GormCore/GormGenericEditor.h>
+#include <GormCore/GormHelpInspector.h>
+#include <GormCore/GormImage.h>
+#include <GormCore/GormImageEditor.h>
+#include <GormCore/GormImageInspector.h>
+#include <GormCore/GormInspectorsManager.h>
+#include <GormCore/GormInternalViewEditor.h>
+#include <GormCore/GormMatrixEditor.h>
+#include <GormCore/GormNSPanel.h>
+#include <GormCore/GormNSSplitViewInspector.h>
+#include <GormCore/GormNSWindow.h>
+#include <GormCore/GormObjectEditor.h>
+#include <GormCore/GormObjectInspector.h>
+#include <GormCore/GormOpenGLView.h>
+#include <GormCore/GormOutlineView.h>
+#include <GormCore/GormPalettesManager.h>
+#include <GormCore/GormPlacementInfo.h>
+#include <GormCore/GormPlugin.h>
+#include <GormCore/GormPluginManager.h>
+#include <GormCore/GormPrivate.h>
+#include <GormCore/GormProtocol.h>
+#include <GormCore/GormResource.h>
+#include <GormCore/GormResourceEditor.h>
+#include <GormCore/GormResourceManager.h>
+#include <GormCore/GormScrollViewAttributesInspector.h>
+#include <GormCore/GormServer.h>
+#include <GormCore/GormSetNameController.h>
+#include <GormCore/GormSound.h>
+#include <GormCore/GormSoundEditor.h>
+#include <GormCore/GormSoundInspector.h>
+#include <GormCore/GormSoundView.h>
+#include <GormCore/GormSplitViewEditor.h>
+#include <GormCore/GormStandaloneViewEditor.h>
+#include <GormCore/GormViewEditor.h>
+#include <GormCore/GormViewKnobs.h>
+#include <GormCore/GormViewSizeInspector.h>
+#include <GormCore/GormViewWindow.h>
+#include <GormCore/GormViewWithContentViewEditor.h>
+#include <GormCore/GormViewWithSubviewsEditor.h>
+#include <GormCore/GormWindowEditor.h>
+#include <GormCore/GormWindowTemplate.h>
+#include <GormCore/GormWrapperBuilder.h>
+#include <GormCore/GormWrapperLoader.h>
+#include <GormCore/NSCell+GormAdditions.h>
+#include <GormCore/NSColorWell+GormExtensions.h>
+#include <GormCore/NSFontManager+GormExtensions.h>
+#include <GormCore/NSView+GormExtensions.h>
+
+#endif
+

--- a/GormCore/GormCustomClassInspector.h
+++ b/GormCore/GormCustomClassInspector.h
@@ -28,7 +28,8 @@
 #define	INCLUDED_GormCustomClassInspector_h
 
 #include <AppKit/AppKit.h>
-#include <InterfaceBuilder/IBInspector.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class GormClassManager;
 

--- a/GormCore/GormCustomClassInspector.m
+++ b/GormCore/GormCustomClassInspector.m
@@ -27,6 +27,7 @@
 /* All Rights reserved */
 
 #include <AppKit/AppKit.h>
+
 #include "GormCustomClassInspector.h"
 #include "GormPrivate.h"
 #include "GormClassManager.h"

--- a/GormCore/GormCustomView.h
+++ b/GormCore/GormCustomView.h
@@ -25,7 +25,7 @@
 #ifndef INCLUDED_GormCustomView_h
 #define INCLUDED_GormCustomView_h
 
-#include <AppKit/NSTextField.h>
+#include <AppKit/AppKit.h>
 
 @interface GormCustomView : NSTextField
 {

--- a/GormCore/GormCustomView.m
+++ b/GormCore/GormCustomView.m
@@ -22,17 +22,16 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <GormCore/GormCustomView.h>
-#include <GormCore/GormPrivate.h>
-#include <GormCore/GormOpenGLView.h>
 
-#include <AppKit/NSColor.h>
-#include <AppKit/NSGraphics.h>
-#include <AppKit/NSFont.h>
+#include <AppKit/AppKit.h>
 #include <AppKit/NSNibLoading.h>
 
 #include <GNUstepGUI/GSGormLoading.h>
 #include <GNUstepGUI/GSNibLoading.h>
+
+#include <GormCore/GormCustomView.h>
+#include <GormCore/GormPrivate.h>
+#include <GormCore/GormOpenGLView.h>
 
 @class GSCustomView;
 

--- a/GormCore/GormDocument.h
+++ b/GormCore/GormDocument.h
@@ -26,10 +26,12 @@
 #ifndef INCLUDED_GormDocument_h
 #define INCLUDED_GormDocument_h
 
-#include <AppKit/AppKit.h>
 #include <Foundation/Foundation.h>
-#include <GNUstepGUI/GSNibContainer.h>
+#include <AppKit/AppKit.h>
+
 #include <InterfaceBuilder/InterfaceBuilder.h>
+
+#include <GNUstepGUI/GSNibContainer.h>
 
 @class GormClassManager, GormClassEditor, GormObjectProxy, GormFilesOwner, 
   GormFilePrefsManager, GormDocumentWindow;

--- a/GormCore/GormDocument.m
+++ b/GormCore/GormDocument.m
@@ -28,6 +28,13 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
+
+#include <GNUstepGUI/GSGormLoading.h>
+
 #include "GormPrivate.h"
 #include "GormClassManager.h"
 #include "GormCustomView.h"
@@ -35,14 +42,6 @@
 #include "GormFunctions.h"
 #include "GormFilePrefsManager.h"
 #include "GormViewWindow.h"
-#include <Foundation/NSUserDefaults.h>
-#include <Foundation/NSException.h>
-#include <AppKit/NSImage.h>
-#include <AppKit/NSSound.h>
-#include <AppKit/NSNibConnector.h>
-#include <AppKit/NSNibLoading.h>
-#include <AppKit/NSScreen.h>
-#include <GNUstepGUI/GSGormLoading.h>
 #include "NSView+GormExtensions.h"
 #include "GormSound.h"
 #include "GormImage.h"

--- a/GormCore/GormDocumentController.h
+++ b/GormCore/GormDocumentController.h
@@ -29,7 +29,7 @@
 #ifndef INCLUDED_GormDocumentController_h
 #define INCLUDED_GormDocumentController_h
 
-#include <AppKit/NSDocumentController.h>
+#include <AppKit/AppKit.h>
 
 typedef enum 
 {

--- a/GormCore/GormDocumentWindow.h
+++ b/GormCore/GormDocumentWindow.h
@@ -22,8 +22,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <AppKit/NSWindow.h>
-#include <GormLib/IBResourceManager.h>
+#include <AppKit/AppKit.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @interface GormDocumentWindow : NSWindow
 {

--- a/GormCore/GormDocumentWindow.m
+++ b/GormCore/GormDocumentWindow.m
@@ -21,12 +21,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
+#include <AppKit/AppKit.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
+
 #include "GormDocumentWindow.h"
 #include "GormPrivate.h"
-
-#include <GormLib/IBResourceManager.h>
-#include <AppKit/NSDragging.h>
-#include <AppKit/NSPasteboard.h>
 
 @implementation GormDocumentWindow
 /*

--- a/GormCore/GormFilePrefsManager.m
+++ b/GormCore/GormFilePrefsManager.m
@@ -30,15 +30,17 @@
 
 /* All Rights reserved */
 
+#include <Foundation/Foundation.h>
 #include <AppKit/AppKit.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
+
+#include <GNUstepBase/GSObjCRuntime.h>
 #include <GNUstepGUI/GSGormLoading.h>
+
 #include "GormFilePrefsManager.h"
 #include "GormFunctions.h"
 #include "GormDocument.h"
-#include <Foundation/NSFileManager.h>
-#include <Foundation/NSArchiver.h>
-#include <GNUstepBase/GSObjCRuntime.h>
-#include <InterfaceBuilder/IBApplicationAdditions.h>
 
 NSString *formatVersion(NSInteger version)
 {

--- a/GormCore/GormFilesOwner.h
+++ b/GormCore/GormFilesOwner.h
@@ -26,8 +26,9 @@
 #ifndef INCLUDED_GormFilesOwner_h
 #define INCLUDED_GormFilesOwner_h
 
-#include <Foundation/NSObject.h>
-#include <InterfaceBuilder/IBInspector.h>
+#include <Foundation/Foundation.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSMutableArray, NSBrowser, NSString;
 

--- a/GormCore/GormFilesOwner.m
+++ b/GormCore/GormFilesOwner.m
@@ -23,7 +23,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
+#include <AppKit/AppKit.h>
 #include <AppKit/NSNibConnector.h>
+
 #include "GormPrivate.h"
 #include "GormCustomView.h"
 

--- a/GormCore/GormFontViewController.m
+++ b/GormCore/GormFontViewController.m
@@ -1,6 +1,7 @@
 /* All Rights reserved */
 
 #include <AppKit/AppKit.h>
+
 #include "GormFontViewController.h"
 
 static GormFontViewController *gorm_font_cont = nil;

--- a/GormCore/GormFunctions.m
+++ b/GormCore/GormFunctions.m
@@ -22,14 +22,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
 #include "GormFunctions.h"
 #include "GormViewEditor.h"
-#include <AppKit/AppKit.h>
-#include <Foundation/NSDictionary.h>
-#include <Foundation/NSUserDefaults.h>
-#include <Foundation/NSFileManager.h>
-#include <Foundation/NSPathUtilities.h>
-#include <Foundation/NSString.h>
 #include "GormClassPanelController.h"
 
 // find all subitems for the given items...

--- a/GormCore/GormGenericEditor.h
+++ b/GormCore/GormGenericEditor.h
@@ -26,9 +26,10 @@
 #ifndef INCLUDED_GormGenericEditor_h
 #define INCLUDED_GormGenericEditor_h
 
-#include <InterfaceBuilder/InterfaceBuilder.h>
 #include <Foundation/Foundation.h>
 #include <AppKit/AppKit.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @interface	GormGenericEditor : NSMatrix <IBEditors, IBSelectionOwners>
 {

--- a/GormCore/GormHelpInspector.h
+++ b/GormCore/GormHelpInspector.h
@@ -1,6 +1,7 @@
 /* All Rights reserved */
 
 #include <AppKit/AppKit.h>
+
 #include <InterfaceBuilder/InterfaceBuilder.h>
 
 @interface GormHelpInspector : IBInspector

--- a/GormCore/GormHelpInspector.m
+++ b/GormCore/GormHelpInspector.m
@@ -1,8 +1,10 @@
 /* All Rights reserved */
 
 #include <AppKit/AppKit.h>
-#include "GormHelpInspector.h"
+
 #include <GNUstepGUI/GSNibLoading.h>
+
+#include "GormHelpInspector.h"
 
 @implementation GormHelpInspector
 - (id) init

--- a/GormCore/GormImage.h
+++ b/GormCore/GormImage.h
@@ -28,7 +28,8 @@
 #ifndef INCLUDED_GormImage_h
 #define INCLUDED_GormImage_h
 
-#include <Foundation/NSObject.h>
+#include <Foundation/Foundation.h>
+
 #include <GormCore/GormResource.h>
 
 @class NSString, NSImage;

--- a/GormCore/GormImage.m
+++ b/GormCore/GormImage.m
@@ -22,8 +22,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <AppKit/NSImage.h>
-#include <InterfaceBuilder/IBObjectAdditions.h>
+#include <AppKit/AppKit.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
+
 #include "GormImage.h"
 
 // implementation of category on NSImage.

--- a/GormCore/GormImageEditor.m
+++ b/GormCore/GormImageEditor.m
@@ -22,11 +22,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
+#include <AppKit/AppKit.h>
+
 #include "GormImageEditor.h"
 #include "GormProtocol.h"
 #include "GormFunctions.h"
 #include "GormPalettesManager.h"
-#include <AppKit/NSImage.h>
 #include "GormImage.h"
 
 @implementation	GormImageEditor

--- a/GormCore/GormImageInspector.h
+++ b/GormCore/GormImageInspector.h
@@ -1,7 +1,8 @@
 /* All Rights reserved */
 
 #include <AppKit/AppKit.h>
-#include <InterfaceBuilder/IBInspector.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @interface GormImageInspector : IBInspector
 {

--- a/GormCore/GormImageInspector.m
+++ b/GormCore/GormImageInspector.m
@@ -1,6 +1,7 @@
 /* All Rights reserved */
 
 #include <AppKit/AppKit.h>
+
 #include "GormImageInspector.h"
 #include "GormPrivate.h"
 #include "GormImage.h"

--- a/GormCore/GormInspectorsManager.h
+++ b/GormCore/GormInspectorsManager.h
@@ -26,9 +26,9 @@
 #ifndef INCLUDED_GormInspectorsManager_h
 #define INCLUDED_GormInspectorsManager_h
 
-#include <Foundation/NSObject.h>
-#include <InterfaceBuilder/IBInspectorManager.h>
-#include <Foundation/NSGeometry.h>
+#include <Foundation/Foundation.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSPanel;
 @class NSMutableDictionary;

--- a/GormCore/GormInspectorsManager.m
+++ b/GormCore/GormInspectorsManager.m
@@ -22,13 +22,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <AppKit/NSNibConnector.h>
-#include <Foundation/NSException.h>
-#include <InterfaceBuilder/IBInspector.h>
-#include <InterfaceBuilder/IBInspectorMode.h>
-#include <InterfaceBuilder/IBObjectAdditions.h>
-#include <InterfaceBuilder/IBInspectorManager.h>
-#include <InterfaceBuilder/IBDocuments.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
+
 #include "GormPrivate.h"
 #include "GormImage.h"
 #include "GormSound.h"

--- a/GormCore/GormInternalViewEditor.m
+++ b/GormCore/GormInternalViewEditor.m
@@ -22,8 +22,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <InterfaceBuilder/IBObjectAdditions.h>
 #include <AppKit/AppKit.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
+
 #include "GormPrivate.h"
 #include "GormInternalViewEditor.h"
 #include "GormFontViewController.h"

--- a/GormCore/GormMatrixEditor.m
+++ b/GormCore/GormMatrixEditor.m
@@ -24,8 +24,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <InterfaceBuilder/IBObjectAdditions.h>
 #include <AppKit/AppKit.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 #include "GormPrivate.h"
 #include "GormImage.h"

--- a/GormCore/GormNSPanel.m
+++ b/GormCore/GormNSPanel.m
@@ -23,8 +23,11 @@
 */
 
 #include <AppKit/AppKit.h>
+
 #include <InterfaceBuilder/InterfaceBuilder.h>
+
 #include <GNUstepGUI/GSGormLoading.h>
+
 #include "GormNSPanel.h"
 
 

--- a/GormCore/GormNSSplitViewInspector.h
+++ b/GormCore/GormNSSplitViewInspector.h
@@ -1,7 +1,8 @@
 /* All Rights reserved */
 
 #include <AppKit/AppKit.h>
-#include <InterfaceBuilder/IBInspector.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @interface GormNSSplitViewInspector : IBInspector
 {

--- a/GormCore/GormNSSplitViewInspector.m
+++ b/GormCore/GormNSSplitViewInspector.m
@@ -1,6 +1,7 @@
 /* All Rights reserved */
 
 #include <AppKit/AppKit.h>
+
 #include "GormNSSplitViewInspector.h"
 
 @implementation NSSplitView (IBObjectAdditions)

--- a/GormCore/GormNSWindow.m
+++ b/GormCore/GormNSWindow.m
@@ -23,8 +23,11 @@
 */
 
 #include <AppKit/AppKit.h>
+
 #include <InterfaceBuilder/InterfaceBuilder.h>
+
 #include <GNUstepGUI/GSGormLoading.h>
+
 #include "GormNSWindow.h"
 
 // the default style mask we start with.

--- a/GormCore/GormObjectEditor.m
+++ b/GormCore/GormObjectEditor.m
@@ -24,14 +24,16 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <InterfaceBuilder/IBObjectAdditions.h>
+#include <AppKit/AppKit.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
+
 #include "GormPrivate.h"
 #include "GormObjectEditor.h"
 #include "GormFunctions.h"
 #include "GormDocument.h"
 #include "GormClassManager.h"
 
-#include <AppKit/NSClipView.h>
 /*
  * Method to return the image that should be used to display objects within
  * the matrix containing the objects in a document.

--- a/GormCore/GormOpenGLView.h
+++ b/GormCore/GormOpenGLView.h
@@ -26,7 +26,7 @@
 #ifndef INCLUDED_GormOpenGLView_h
 #define INCLUDED_GormOpenGLView_h
 
-#include <AppKit/NSView.h>
+#include <AppKit/AppKit.h>
 
 @class NSTimer;
 

--- a/GormCore/GormOpenGLView.m
+++ b/GormCore/GormOpenGLView.m
@@ -23,9 +23,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
 #include <GormCore/GormOpenGLView.h>
-#include <Foundation/NSTimer.h>
-#include <AppKit/PSOperators.h>
 // #include <AppKit/NSOpenGL.h>
 // #include <GL/gl.h>
 

--- a/GormCore/GormOutlineView.h
+++ b/GormCore/GormOutlineView.h
@@ -29,8 +29,8 @@
 #ifndef INCLUDED_GormOutlineView_h
 #define INCLUDED_GormOutlineView_h
 
-#include <AppKit/NSOutlineView.h>
-#include <Foundation/NSMapTable.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
 
 @class NSTableColumn;
 @class NSMenuItem;

--- a/GormCore/GormOutlineView.m
+++ b/GormCore/GormOutlineView.m
@@ -25,19 +25,10 @@
    59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 */ 
 
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
 #include "GormOutlineView.h"
-#include <Foundation/NSNotification.h>
-#include <Foundation/NSNull.h>
-#include <Foundation/NSException.h>
-#include <Foundation/NSDebug.h>
-#include <Foundation/NSIndexSet.h>
-#include <AppKit/NSTableColumn.h>
-#include <AppKit/NSCell.h>
-#include <AppKit/NSEvent.h>
-#include <AppKit/NSMenuItem.h>
-#include <AppKit/NSTextFieldCell.h>
-#include <AppKit/NSWindow.h>
-#include <AppKit/NSImage.h>
 
 static NSNotificationCenter *nc = nil;
 static const NSInteger current_version = 1;

--- a/GormCore/GormPalettesManager.h
+++ b/GormCore/GormPalettesManager.h
@@ -26,7 +26,7 @@
 #ifndef INCLUDED_GormPalettesManager_h
 #define INCLUDED_GormPalettesManager_h
 
-#include <Foundation/NSObject.h>
+#include <Foundation/Foundation.h>
 
 @class NSMutableArray, NSMutableDictionary, NSDictionary, NSArray, NSBundle;
 @class NSPanel, NSMatrix, NSView;

--- a/GormCore/GormPalettesManager.m
+++ b/GormCore/GormPalettesManager.m
@@ -23,12 +23,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include "GormPrivate.h"
-#include <Foundation/NSArray.h>
-#include <Foundation/NSSet.h>
-#include <AppKit/NSImage.h>
-#include <AppKit/NSSound.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
 #include <GNUstepBase/GSObjCRuntime.h>
+
+#include "GormPrivate.h"
 #include "GormFunctions.h"
 
 #define BUILTIN_PALETTES @"BuiltinPalettes"

--- a/GormCore/GormPlacementInfo.h
+++ b/GormCore/GormPlacementInfo.h
@@ -24,7 +24,8 @@
 #ifndef	INCLUDED_GormPlacementInfo_h
 #define	INCLUDED_GormPlacementInfo_h
 
-#include <Foundation/NSObject.h>
+#include <Foundation/Foundation.h>
+
 #include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSView, NSMutableArray;

--- a/GormCore/GormPlugin.h
+++ b/GormCore/GormPlugin.h
@@ -23,7 +23,8 @@
 
 #ifndef GORM_GORMPLUGIN
 #define GORM_GORMPLUGIN
-#include <InterfaceBuilder/IBPlugin.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSString, NSArray;
 

--- a/GormCore/GormPlugin.m
+++ b/GormCore/GormPlugin.m
@@ -22,7 +22,8 @@
  */
 
 #include <Foundation/Foundation.h>
-#include <AppKit/NSDocumentController.h>
+#include <AppKit/AppKit.h>
+
 #include <GormCore/GormPlugin.h>
 
 @interface NSDocumentController (GormPrivate)

--- a/GormCore/GormPluginManager.h
+++ b/GormCore/GormPluginManager.h
@@ -26,7 +26,7 @@
 #ifndef INCLUDED_GormPluginManager_h
 #define INCLUDED_GormPluginManager_h
 
-#include <Foundation/NSObject.h>
+#include <Foundation/Foundation.h>
 
 @class NSMutableArray, NSMutableDictionary, NSDictionary, NSArray, NSBundle;
 @class NSPanel, NSMatrix, NSView;

--- a/GormCore/GormPluginManager.m
+++ b/GormCore/GormPluginManager.m
@@ -23,12 +23,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include "GormPrivate.h"
-#include <Foundation/NSArray.h>
-#include <Foundation/NSSet.h>
-#include <AppKit/NSImage.h>
-#include <AppKit/NSSound.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
 #include <GNUstepBase/GSObjCRuntime.h>
+
+#include "GormPrivate.h"
 #include "GormFunctions.h"
 #include "GormPluginManager.h"
 

--- a/GormCore/GormPrivate.h
+++ b/GormCore/GormPrivate.h
@@ -26,9 +26,11 @@
 #ifndef INCLUDED_GormPrivate_h
 #define INCLUDED_GormPrivate_h
 
-#include <InterfaceBuilder/IBApplicationAdditions.h>
-#include <InterfaceBuilder/IBInspector.h>
-#include <InterfaceBuilder/IBViewAdditions.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
+
+#include <GNUstepGUI/GSGormLoading.h>
+#include <GNUstepGUI/GSNibLoading.h>
+
 #include <GormCore/GormFilesOwner.h>
 #include <GormCore/GormDocument.h>
 #include <GormCore/GormInspectorsManager.h>
@@ -36,8 +38,6 @@
 #include <GormCore/GormPalettesManager.h>
 #include <GormCore/GormProtocol.h>
 #include <GormCore/GormClassEditor.h>
-#include <GNUstepGUI/GSGormLoading.h>
-#include <GNUstepGUI/GSNibLoading.h>
 
 extern NSString *GormLinkPboardType;
 extern NSString *GormToggleGuidelineNotification;

--- a/GormCore/GormPrivate.m
+++ b/GormCore/GormPrivate.m
@@ -23,15 +23,15 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
+// for templates...
+#include <AppKit/AppKit.h>
+
+#include <GNUstepBase/GSObjCRuntime.h>
+#include <GNUstepGUI/GSNibLoading.h>
+
 #include "GormPrivate.h"
 #include "GormFontViewController.h"
 #include "GormSetNameController.h"
-#include "GNUstepGUI/GSNibLoading.h"
-#include "GNUstepBase/GSObjCRuntime.h"
-
-// for templates...
-#include <AppKit/NSControl.h>
-#include <AppKit/NSButton.h>
 
 NSString *GormToggleGuidelineNotification = @"GormToggleGuidelineNotification";
 NSString *GormDidModifyClassNotification = @"GormDidModifyClassNotification";

--- a/GormCore/GormProtocol.h
+++ b/GormCore/GormProtocol.h
@@ -25,7 +25,7 @@
 #ifndef INCLUDED_GormProtocol_h
 #define INCLUDED_GormProtocol_h
 
-#include <Foundation/NSObject.h>
+#include <Foundation/Foundation.h>
 
 @class GormClassManager, GormPalettesManager, GormInspectorsManager, NSString, NSMenu, GormPluginManager;
 

--- a/GormCore/GormResource.h
+++ b/GormCore/GormResource.h
@@ -28,10 +28,9 @@
 #ifndef INCLUDED_GormResource_h
 #define INCLUDED_GormResource_h
 
-#include <Foundation/NSObject.h>
-#include <InterfaceBuilder/IBProjectFiles.h>
-#include <InterfaceBuilder/IBProjects.h>
-#include <InterfaceBuilder/IBObjectAdditions.h>
+#include <Foundation/Foundation.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSString, NSData;
 

--- a/GormCore/GormResource.m
+++ b/GormCore/GormResource.m
@@ -22,9 +22,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <Foundation/NSData.h>
-#include <Foundation/NSObject.h>
-#include <Foundation/NSString.h>
+#include <Foundation/Foundation.h>
+
 #include "GormResource.h"
 
 // resource proxy object...

--- a/GormCore/GormResourceEditor.m
+++ b/GormCore/GormResourceEditor.m
@@ -22,7 +22,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <AppKit/NSImage.h>
+#include <AppKit/AppKit.h>
+
 #include "GormDocument.h"
 #include "GormPrivate.h"
 #include "GormResourceEditor.h"

--- a/GormCore/GormResourceManager.h
+++ b/GormCore/GormResourceManager.h
@@ -25,7 +25,7 @@
 #ifndef INCLUDED_GORMVIEWRESOURCEMANAGER_H
 #define INCLUDED_GORMVIEWRESOURCEMANAGER_H
 
-#include <InterfaceBuilder/IBResourceManager.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @interface GormResourceManager : IBResourceManager
 @end

--- a/GormCore/GormResourceManager.m
+++ b/GormCore/GormResourceManager.m
@@ -22,12 +22,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <Foundation/NSArray.h>
-#include <Foundation/NSArchiver.h>
-#include <AppKit/NSSound.h>
-#include <AppKit/NSImage.h>
-#include <AppKit/NSPasteboard.h>
-#include <InterfaceBuilder/IBPalette.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 #include "GormSound.h"
 #include "GormImage.h"

--- a/GormCore/GormScrollViewAttributesInspector.h
+++ b/GormCore/GormScrollViewAttributesInspector.h
@@ -27,7 +27,8 @@
 /* All Rights reserved */
 
 #include <AppKit/AppKit.h>
-#include <InterfaceBuilder/IBInspector.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @interface GormScrollViewAttributesInspector : IBInspector
 {

--- a/GormCore/GormScrollViewAttributesInspector.m
+++ b/GormCore/GormScrollViewAttributesInspector.m
@@ -27,6 +27,7 @@
 /* All Rights reserved */
 
 #include <AppKit/AppKit.h>
+
 #include "GormScrollViewAttributesInspector.h"
 
 @implementation GormScrollViewAttributesInspector

--- a/GormCore/GormScrollViewEditor.m
+++ b/GormCore/GormScrollViewEditor.m
@@ -24,7 +24,9 @@
  */
 
 #include <AppKit/AppKit.h>
-#include <InterfaceBuilder/IBObjectAdditions.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
+
 #include "GormPrivate.h"
 #include "GormBoxEditor.h"
 #include "GormViewKnobs.h"

--- a/GormCore/GormSetNameController.h
+++ b/GormCore/GormSetNameController.h
@@ -6,7 +6,7 @@
 #ifndef GORM_SET_NAME_CONTROLLER_H
 #define GORM_SET_NAME_CONTROLLER_H
 
-#include <Foundation/NSObject.h>
+#include <Foundation/Foundation.h>
 
 @class NSButton, NSPanel, NSTextField;
 

--- a/GormCore/GormSetNameController.m
+++ b/GormCore/GormSetNameController.m
@@ -1,14 +1,9 @@
 // Author: Andrew E. Ruder
 // Copyright (C) 2003 by Free Software Foundation, Inc
 
-#include "GormSetNameController.h"
+#include <AppKit/AppKit.h>
 
-#include <AppKit/NSApplication.h>
-#include <AppKit/NSButton.h>
-#include <AppKit/NSTextField.h>
-#include <AppKit/NSPanel.h>
-#include <AppKit/NSNibLoading.h>
-#include <AppKit/NSPanel.h>
+#include "GormSetNameController.h"
 
 @implementation GormSetNameController : NSObject
 - (NSInteger)runAsModal

--- a/GormCore/GormSound.h
+++ b/GormCore/GormSound.h
@@ -28,7 +28,8 @@
 #ifndef INCLUDED_GormSound_h
 #define INCLUDED_GormSound_h
 
-#include <Foundation/NSObject.h>
+#include <Foundation/Foundation.h>
+
 #include <GormCore/GormResource.h>
 
 @class NSString;

--- a/GormCore/GormSound.m
+++ b/GormCore/GormSound.m
@@ -22,10 +22,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <Foundation/NSString.h>
-#include <AppKit/NSSound.h>
-#include <AppKit/NSImage.h>
-#include <InterfaceBuilder/IBObjectAdditions.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
+
 #include "GormSound.h"
 
 // sound proxy object...

--- a/GormCore/GormSoundEditor.m
+++ b/GormCore/GormSoundEditor.m
@@ -22,11 +22,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
+#include <AppKit/AppKit.h>
+
 #include "GormSoundEditor.h"
 #include "GormProtocol.h"
 #include "GormFunctions.h"
 #include "GormPalettesManager.h"
-#include <AppKit/NSSound.h>
 #include "GormSound.h"
 
 @implementation	GormSoundEditor

--- a/GormCore/GormSoundInspector.h
+++ b/GormCore/GormSoundInspector.h
@@ -27,6 +27,7 @@
 #define	INCLUDED_GormSoundInspector_h
 
 #include <AppKit/AppKit.h>
+
 #include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class GormClassManager;

--- a/GormCore/GormSoundInspector.m
+++ b/GormCore/GormSoundInspector.m
@@ -27,6 +27,7 @@
 /* All Rights reserved */
 
 #include <AppKit/AppKit.h>
+
 #include "GormSoundInspector.h"
 #include "GormPrivate.h"
 #include "GormClassManager.h"

--- a/GormCore/GormSoundView.m
+++ b/GormCore/GormSoundView.m
@@ -27,8 +27,9 @@
 /* All Rights reserved */
 
 #include <AppKit/AppKit.h>
-#include "GormSoundView.h"
 #include <AppKit/PSOperators.h>
+
+#include "GormSoundView.h"
 
 // add a data method to the NSSound class...
 @interface NSSound (SoundView)

--- a/GormCore/GormSplitViewEditor.m
+++ b/GormCore/GormSplitViewEditor.m
@@ -22,8 +22,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <InterfaceBuilder/IBObjectAdditions.h>
 #include <AppKit/AppKit.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 #include "GormPrivate.h"
 #include "GormSplitViewEditor.h"

--- a/GormCore/GormStandaloneViewEditor.m
+++ b/GormCore/GormStandaloneViewEditor.m
@@ -23,6 +23,7 @@
  */
 
 #include <AppKit/AppKit.h>
+
 #include <GormCore/GormPrivate.h>
 #include <GormCore/GormStandaloneViewEditor.h>
 #include <GormCore/GormDefines.h>

--- a/GormCore/GormViewEditor.m
+++ b/GormCore/GormViewEditor.m
@@ -22,8 +22,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
+#include <Foundation/Foundation.h>
 #include <AppKit/AppKit.h>
-#include <Foundation/NSUserDefaults.h>
+
 #include <InterfaceBuilder/InterfaceBuilder.h>
 
 #include "GormGenericEditor.h"

--- a/GormCore/GormViewKnobs.h
+++ b/GormCore/GormViewKnobs.h
@@ -29,6 +29,7 @@
 
 #include <Foundation/Foundation.h>
 #include <AppKit/AppKit.h>
+
 #include <InterfaceBuilder/InterfaceBuilder.h>
 
 void

--- a/GormCore/GormViewKnobs.m
+++ b/GormCore/GormViewKnobs.m
@@ -26,6 +26,7 @@
 */
 
 #include "GormViewKnobs.h"
+
 #include <math.h>
 
 static NSInteger KNOB_WIDTH = 0.0;

--- a/GormCore/GormViewSizeInspector.h
+++ b/GormCore/GormViewSizeInspector.h
@@ -28,7 +28,7 @@
 #ifndef INCLUDED_GormViewSizeInspector_h
 #define INCLUDED_GormViewSizeInspector_h
 
-#include <InterfaceBuilder/IBInspector.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSButton, NSForm;
 

--- a/GormCore/GormViewSizeInspector.m
+++ b/GormCore/GormViewSizeInspector.m
@@ -22,11 +22,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
+#include <InterfaceBuilder/InterfaceBuilder.h>
+
 #include "GormPrivate.h"
 #include "GormViewKnobs.h"
 #include "GormViewSizeInspector.h"
 #include "GormViewWindow.h"
-#include <InterfaceBuilder/IBApplicationAdditions.h>
 
 @implementation GormViewSizeInspector
 

--- a/GormCore/GormViewWindow.h
+++ b/GormCore/GormViewWindow.h
@@ -25,8 +25,7 @@
 #ifndef INCLUDED_GormViewWindow_h
 #define INCLUDED_GormViewWindow_h
 
-#include <AppKit/NSWindow.h>
-#include <AppKit/NSView.h>
+#include <AppKit/AppKit.h>
 
 @interface GormViewWindow : NSWindow
 {

--- a/GormCore/GormViewWindow.m
+++ b/GormCore/GormViewWindow.m
@@ -22,13 +22,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include "GormViewWindow.h"
-#include <AppKit/NSWindow.h>
-#include <AppKit/NSView.h>
-#include <AppKit/NSColor.h>
-#include <Foundation/NSNotification.h>
-#include <Foundation/NSException.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
 #include <InterfaceBuilder/InterfaceBuilder.h>
+
+#include "GormViewWindow.h"
 #include "GormFunctions.h"
 
 @interface GormViewWindowDelegate : NSObject

--- a/GormCore/GormViewWithContentViewEditor.m
+++ b/GormCore/GormViewWithContentViewEditor.m
@@ -23,6 +23,7 @@
  */
 
 #include <AppKit/AppKit.h>
+
 #include "GormPrivate.h"
 #include "GormViewWithContentViewEditor.h"
 #include "GormPlacementInfo.h"

--- a/GormCore/GormViewWithSubviewsEditor.m
+++ b/GormCore/GormViewWithSubviewsEditor.m
@@ -23,6 +23,7 @@
  */
 
 #include <AppKit/AppKit.h>
+
 #include <GormCore/GormPrivate.h>
 #include <GormCore/GormViewWithSubviewsEditor.h>
 #include <GormCore/GormFontViewController.h>

--- a/GormCore/GormWindowEditor.h
+++ b/GormCore/GormWindowEditor.h
@@ -27,8 +27,8 @@
 #ifndef INCLUDED_GormWindowEditor_h
 #define INCLUDED_GormWindowEditor_h
 
-#include <InterfaceBuilder/IBDocuments.h>
-#include <InterfaceBuilder/IBEditors.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
+
 #include <GormCore/GormViewWithContentViewEditor.h>
 
 @class NSMutableArray, NSString, NSView, NSPasteboard;

--- a/GormCore/GormWindowEditor.m
+++ b/GormCore/GormWindowEditor.m
@@ -24,8 +24,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <InterfaceBuilder/IBViewAdditions.h>
-#include <InterfaceBuilder/IBObjectAdditions.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 #include "GormPrivate.h"
 #include "GormViewWithContentViewEditor.h"

--- a/GormCore/GormWindowTemplate.h
+++ b/GormCore/GormWindowTemplate.h
@@ -24,6 +24,7 @@
 
 #include <Foundation/Foundation.h>
 #include <AppKit/AppKit.h>
+
 #include <GNUstepGUI/GSNibLoading.h>
 
 @interface NSWindowTemplate (Private)

--- a/GormCore/GormWrapperBuilder.h
+++ b/GormCore/GormWrapperBuilder.h
@@ -27,7 +27,7 @@
 #ifndef INCLUDED_GormWrapperBuilder_h
 #define INCLUDED_GormWrapperBuilder_h
 
-#include <Foundation/NSObject.h>
+#include <Foundation/Foundation.h>
 
 @class NSFileWrapper, GormDocument, NSString, NSMutableDictionary;
 

--- a/GormCore/GormWrapperBuilder.m
+++ b/GormCore/GormWrapperBuilder.m
@@ -25,9 +25,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <AppKit/NSFileWrapper.h>
-#include <Foundation/NSString.h>
-#include <Foundation/NSDictionary.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
 #include <GormCore/GormWrapperBuilder.h>
 #include <GormCore/GormDocument.h>
 #include <GormCore/GormPrivate.h>

--- a/GormCore/GormWrapperLoader.h
+++ b/GormCore/GormWrapperLoader.h
@@ -27,7 +27,7 @@
 #ifndef INCLUDED_GormWrapperLoader_h
 #define INCLUDED_GormWrapperLoader_h
 
-#include <Foundation/NSObject.h>
+#include <Foundation/Foundation.h>
 
 @class NSFileWrapper, GormDocument, NSString;
 

--- a/GormCore/GormWrapperLoader.m
+++ b/GormCore/GormWrapperLoader.m
@@ -25,8 +25,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <AppKit/NSFileWrapper.h>
-#include <Foundation/NSString.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
 #include <GormCore/GormWrapperLoader.h>
 #include <GormCore/GormDocument.h>
 #include <GormCore/GormPrivate.h>

--- a/GormCore/NSCell+GormAdditions.h
+++ b/GormCore/NSCell+GormAdditions.h
@@ -25,7 +25,7 @@
 #ifndef INCLUDED_NSCellGormAdditions_h
 #define INCLUDED_NSCellGormAdditions_h
 
-#include <AppKit/NSCell.h>
+#include <AppKit/AppKit.h>
 
 @class NSText;
 

--- a/GormCore/NSCell+GormAdditions.m
+++ b/GormCore/NSCell+GormAdditions.m
@@ -23,7 +23,8 @@
  */
 
 #include <Foundation/Foundation.h>
-#include <AppKit/NSText.h>
+#include <AppKit/AppKit.h>
+
 #include "NSCell+GormAdditions.h"
 
 @implementation NSCell (GormAdditions)

--- a/GormCore/NSColorWell+GormExtensions.h
+++ b/GormCore/NSColorWell+GormExtensions.h
@@ -25,8 +25,7 @@
 #ifndef INCLUDED_NSColorWell_GormExtensions_h
 #define INCLUDED_NSColorWell_GormExtensions_h
 
-#include <AppKit/NSColor.h>
-#include <AppKit/NSColorWell.h>
+#include <AppKit/AppKit.h>
 
 @interface NSColorWell (GormExtensions)
 /**

--- a/GormCore/NSColorWell+GormExtensions.m
+++ b/GormCore/NSColorWell+GormExtensions.m
@@ -22,8 +22,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <AppKit/NSView.h>
-#include <AppKit/NSColorPanel.h>
+#include <AppKit/AppKit.h>
+
 #include "NSColorWell+GormExtensions.h"
 
 @implementation NSColorWell (GormExtensions)

--- a/GormCore/NSFontManager+GormExtensions.h
+++ b/GormCore/NSFontManager+GormExtensions.h
@@ -25,7 +25,7 @@
 #ifndef INCLUDED_NSFontManager_GormExtensions_h
 #define INCLUDED_NSFontManager_GormExtensions_h
 
-#include <AppKit/NSFontManager.h>
+#include <AppKit/AppKit.h>
 
 @interface NSFontManager (GormExtensions)
 

--- a/GormCore/NSFontManager+GormExtensions.m
+++ b/GormCore/NSFontManager+GormExtensions.m
@@ -22,9 +22,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <Foundation/NSObject.h>
-#include <Foundation/NSException.h>
-#include <AppKit/NSApplication.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
 #include "NSFontManager+GormExtensions.h"
 #include "GormDocument.h"
 

--- a/GormCore/NSView+GormExtensions.h
+++ b/GormCore/NSView+GormExtensions.h
@@ -25,7 +25,7 @@
 #ifndef INCLUDED_NSView_GormExtensions_h
 #define INCLUDED_NSView_GormExtensions_h
 
-#include <AppKit/NSView.h>
+#include <AppKit/AppKit.h>
 
 @class NSArray;
 

--- a/GormCore/NSView+GormExtensions.m
+++ b/GormCore/NSView+GormExtensions.m
@@ -22,13 +22,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <Foundation/NSArray.h>
-#include <Foundation/NSEnumerator.h>
-#include <Foundation/NSDebug.h>
-#include <Foundation/NSException.h>
+#include <Foundation/Foundation.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 #include "NSView+GormExtensions.h"
-#include <InterfaceBuilder/IBViewResourceDragging.h>
 
 static Ivar subviews_ivar(void)
 {

--- a/GormLib/IBApplicationAdditions.m
+++ b/GormLib/IBApplicationAdditions.m
@@ -22,7 +22,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <Foundation/NSString.h>
+#include <Foundation/Foundation.h>
 
 NSString *IBWillBeginTestingInterfaceNotification
   = @"IBWillBeginTestingInterfaceNotification";

--- a/GormLib/IBCellAdditions.h
+++ b/GormLib/IBCellAdditions.h
@@ -25,7 +25,8 @@
 #ifndef INCLUDED_IBCELLADDITIONS_H
 #define INCLUDED_IBCELLADDITIONS_H
 
-#include <AppKit/NSCell.h>
+#include <AppKit/AppKit.h>
+
 #include <InterfaceBuilder/IBCellProtocol.h>
 
 @interface NSCell (IBCellAdditions) <IBCellProtocol>

--- a/GormLib/IBCellProtocol.h
+++ b/GormLib/IBCellProtocol.h
@@ -25,7 +25,8 @@
 #ifndef INCLUDED_IBCELLPROTOCOL_H
 #define INCLUDED_IBCELLPROTOCOL_H
 
-#include <Foundation/NSGeometry.h>
+#include <Foundation/Foundation.h>
+
 #include <InterfaceBuilder/IBDefines.h>
 
 @protocol IBCellProtocol

--- a/GormLib/IBConnectors.h
+++ b/GormLib/IBConnectors.h
@@ -25,9 +25,10 @@
 #ifndef INCLUDED_IBCONNECTORS_H
 #define INCLUDED_IBCONNECTORS_H
 
-#include <Foundation/NSObject.h>
-#include <AppKit/NSApplication.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
 #include <AppKit/NSNibConnector.h>
+
 #include <InterfaceBuilder/IBSystem.h>
 
 // forward declarations

--- a/GormLib/IBConnectors.m
+++ b/GormLib/IBConnectors.m
@@ -22,8 +22,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <Foundation/NSString.h>
-#include <AppKit/NSNibConnector.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
 
 NSString *IBWillAddConnectorNotification
   = @"IBWillAddConnectorNotification";

--- a/GormLib/IBDocuments.h
+++ b/GormLib/IBDocuments.h
@@ -25,7 +25,8 @@
 #ifndef INCLUDED_IBDOCUMENTS_H
 #define INCLUDED_IBDOCUMENTS_H
 
-#include <Foundation/NSGeometry.h>
+#include <Foundation/Foundation.h>
+
 #include <InterfaceBuilder/IBEditors.h>
 #include <InterfaceBuilder/IBConnectors.h>
 #include <InterfaceBuilder/IBSystem.h>

--- a/GormLib/IBDocuments.m
+++ b/GormLib/IBDocuments.m
@@ -22,7 +22,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <Foundation/NSString.h>
+#include <Foundation/Foundation.h>
+
 #include <InterfaceBuilder/IBDocuments.h>
 
 NSString *IBDidOpenDocumentNotification = @"IBDidOpenDocumentNotification";

--- a/GormLib/IBEditors.h
+++ b/GormLib/IBEditors.h
@@ -25,7 +25,8 @@
 #ifndef INCLUDED_IBEDITORS_H
 #define INCLUDED_IBEDITORS_H
 
-#include <Foundation/NSObject.h>
+#include <Foundation/Foundation.h>
+
 #include <InterfaceBuilder/IBSystem.h>
 
 // forward references

--- a/GormLib/IBEditors.m
+++ b/GormLib/IBEditors.m
@@ -22,7 +22,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <Foundation/NSString.h>
+#include <Foundation/Foundation.h>
 
 NSString *IBAttributesChangedNotification
   = @"IBAttributesChangedNotification";

--- a/GormLib/IBInspector.h
+++ b/GormLib/IBInspector.h
@@ -25,7 +25,8 @@
 #ifndef INCLUDED_IBINSPECTOR_H
 #define INCLUDED_IBINSPECTOR_H
 
-#include <Foundation/NSObject.h>
+#include <Foundation/Foundation.h>
+
 #include <InterfaceBuilder/IBObjectProtocol.h>
 
 #define	IVH	388	/* Standard height of inspector view.	*/

--- a/GormLib/IBInspector.m
+++ b/GormLib/IBInspector.m
@@ -22,12 +22,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
 #include <InterfaceBuilder/IBApplicationAdditions.h>
 #include <InterfaceBuilder/IBInspector.h>
 #include <InterfaceBuilder/IBDocuments.h>
-#include <Foundation/NSString.h>
-#include <Foundation/NSNotification.h>
-#include <AppKit/NSWindow.h>
 
 static NSNotificationCenter *nc = nil;
 

--- a/GormLib/IBInspectorManager.h
+++ b/GormLib/IBInspectorManager.h
@@ -25,7 +25,8 @@
 #ifndef INCLUDED_IBINSPECTORMANAGER_H
 #define INCLUDED_IBINSPECTORMANAGER_H
 
-#include <Foundation/NSObject.h>
+#include <Foundation/Foundation.h>
+
 #include <InterfaceBuilder/IBSystem.h>
 
 @class NSString, NSMutableArray;

--- a/GormLib/IBInspectorManager.m
+++ b/GormLib/IBInspectorManager.m
@@ -22,13 +22,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <Foundation/NSObject.h>
-#include <Foundation/NSString.h>
-#include <Foundation/NSDictionary.h>
-#include <Foundation/NSArray.h>
-#include <Foundation/NSEnumerator.h>
+#include <Foundation/Foundation.h>
+
 #include <InterfaceBuilder/IBInspectorManager.h>
 #include <InterfaceBuilder/IBInspectorMode.h>
+
 #include <math.h>
 
 static IBInspectorManager *_sharedInspectorManager = nil;

--- a/GormLib/IBInspectorMode.h
+++ b/GormLib/IBInspectorMode.h
@@ -25,7 +25,7 @@
 #ifndef IBINSPECTORMODE_H
 #define IBINSPECTORMODE_H
 
-#include <Foundation/NSObject.h>
+#include <Foundation/Foundation.h>
 
 @class NSString;
 

--- a/GormLib/IBInspectorMode.m
+++ b/GormLib/IBInspectorMode.m
@@ -22,9 +22,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
+#include <Foundation/Foundation.h>
+
 #include <InterfaceBuilder/IBInspectorMode.h>
-#include <Foundation/NSArray.h>
-#include <Foundation/NSString.h>
 
 /**
  * IBInspectorMode is an internal class in the InterfaceBuilder framework.

--- a/GormLib/IBObjectAdditions.m
+++ b/GormLib/IBObjectAdditions.m
@@ -22,8 +22,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <Foundation/NSObject.h>
-#include <Foundation/NSObjCRuntime.h>
+#include <Foundation/Foundation.h>
+
 #include <InterfaceBuilder/IBObjectAdditions.h>
 
 // object additions -- object adopts protocol

--- a/GormLib/IBPalette.h
+++ b/GormLib/IBPalette.h
@@ -25,8 +25,8 @@
 #ifndef INCLUDED_IBPALETTE_H
 #define INCLUDED_IBPALETTE_H
 
-#include <Foundation/NSMapTable.h>
-#include <Foundation/NSObject.h>
+#include <Foundation/Foundation.h>
+
 #include <InterfaceBuilder/IBDocuments.h>
 #include <InterfaceBuilder/IBSystem.h>
 

--- a/GormLib/IBPalette.m
+++ b/GormLib/IBPalette.m
@@ -22,9 +22,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <InterfaceBuilder/IBPalette.h>
 #include <Foundation/Foundation.h>
 #include <AppKit/AppKit.h>
+
+#include <InterfaceBuilder/IBPalette.h>
 
 NSString	*IBCellPboardType = @"IBCellPboardType";
 NSString	*IBMenuPboardType = @"IBMenuPboardType";

--- a/GormLib/IBPlugin.h
+++ b/GormLib/IBPlugin.h
@@ -25,7 +25,8 @@
 #ifndef INCLUDED_IBPLUGIN_H
 #define INCLUDED_IBPLUGIN_H
 
-#include <Foundation/NSObject.h>
+#include <Foundation/Foundation.h>
+
 #include <InterfaceBuilder/IBDocuments.h>
 
 // forward references

--- a/GormLib/IBPlugin.m
+++ b/GormLib/IBPlugin.m
@@ -22,9 +22,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <Foundation/NSObject.h>
-#include <Foundation/NSString.h>
-#include <AppKit/NSView.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
 #include <InterfaceBuilder/IBPlugin.h>
 
 static NSMapTable *instanceMap = 0;

--- a/GormLib/IBProjects.h
+++ b/GormLib/IBProjects.h
@@ -25,8 +25,8 @@
 #ifndef INCLUDED_IBPROJECTS_H
 #define INCLUDED_IBPROJECTS_H
 
-#include <Foundation/NSObject.h>
-#include <AppKit/NSInterfaceStyle.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
 
 @class NSString, NSArray;
 

--- a/GormLib/IBResourceManager.h
+++ b/GormLib/IBResourceManager.h
@@ -25,8 +25,8 @@
 #ifndef INCLUDED_IBRESOURCEMANAGER_H
 #define INCLUDED_IBRESOURCEMANAGER_H
 
-#include <Foundation/NSObject.h>
-#include <Foundation/NSArray.h>
+#include <Foundation/Foundation.h>
+
 #include <InterfaceBuilder/IBProjects.h>
 #include <InterfaceBuilder/IBProjectFiles.h>
 #include <InterfaceBuilder/IBDocuments.h>

--- a/GormLib/IBResourceManager.m
+++ b/GormLib/IBResourceManager.m
@@ -22,18 +22,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
 #include <InterfaceBuilder/IBResourceManager.h>
 #include <InterfaceBuilder/IBObjectAdditions.h>
 #include <InterfaceBuilder/IBPalette.h>
-#include <Foundation/NSArchiver.h>
-#include <Foundation/NSArray.h>
-#include <Foundation/NSEnumerator.h>
-#include <Foundation/NSException.h>
-#include <Foundation/NSMapTable.h>
-#include <Foundation/NSNotification.h> 
-#include <Foundation/NSNull.h>
-#include <Foundation/NSString.h>
-#include <AppKit/NSPasteboard.h>
 
 NSString *IBResourceManagerRegistryDidChangeNotification = @"IBResourceManagerRegistryDidChangeNotification";
 

--- a/GormLib/IBViewAdditions.h
+++ b/GormLib/IBViewAdditions.h
@@ -25,8 +25,9 @@
 #ifndef INCLUDED_IBVIEWADDITIONS_H
 #define INCLUDED_IBVIEWADDITIONS_H
 
+#include <AppKit/AppKit.h>
+
 #include <InterfaceBuilder/IBViewProtocol.h>
-#include <AppKit/NSView.h>
 
 @interface NSView (IBViewAdditions) <IBViewProtocol>
 @end

--- a/GormLib/IBViewProtocol.h
+++ b/GormLib/IBViewProtocol.h
@@ -25,8 +25,10 @@
 #ifndef INCLUDED_IBVIEWPROTOCOL_H
 #define INCLUDED_IBVIEWPROTOCOL_H
 
+#include <Foundation/Foundation.h>
+
 #include <InterfaceBuilder/IBDefines.h>
-#include <Foundation/NSGeometry.h>
+
 
 // forward references
 @class NSColor;

--- a/GormLib/IBViewResourceDragging.h
+++ b/GormLib/IBViewResourceDragging.h
@@ -25,7 +25,7 @@
 #ifndef INCLUDED_IBVIEWRESOURCEDRAGGING_H
 #define INCLUDED_IBVIEWRESOURCEDRAGGING_H
 
-#include <AppKit/NSView.h>
+#include <AppKit/AppKit.h>
 
 @class NSPasteboard;
 

--- a/GormLib/InterfaceBuilder.h
+++ b/GormLib/InterfaceBuilder.h
@@ -22,6 +22,17 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
+
+#import <Foundation/Foundation.h>
+
+#ifndef GNUSTEP
+//! Project version number for InterfaceBuilder.
+FOUNDATION_EXPORT double InterfaceBuilderVersionNumber;
+
+//! Project version string for InterfaceBuilder.
+FOUNDATION_EXPORT const unsigned char InterfaceBuilderVersionString[];
+#endif
+
 #ifndef INCLUDED_INTERFACEBUILDER_H
 #define INCLUDED_INTERFACEBUILDER_H
  
@@ -34,12 +45,13 @@
 #include <InterfaceBuilder/IBEditors.h>
 #include <InterfaceBuilder/IBInspector.h>
 #include <InterfaceBuilder/IBInspectorManager.h>
+#include <InterfaceBuilder/IBInspectorMode.h>
 #include <InterfaceBuilder/IBObjectAdditions.h>
 #include <InterfaceBuilder/IBObjectProtocol.h>
 #include <InterfaceBuilder/IBPalette.h>
 #include <InterfaceBuilder/IBPlugin.h>
-#include <InterfaceBuilder/IBProjects.h>
 #include <InterfaceBuilder/IBProjectFiles.h>
+#include <InterfaceBuilder/IBProjects.h>
 #include <InterfaceBuilder/IBResourceManager.h>
 #include <InterfaceBuilder/IBSystem.h>
 #include <InterfaceBuilder/IBViewAdditions.h>

--- a/GormObjCHeaderParser/GNUmakefile
+++ b/GormObjCHeaderParser/GNUmakefile
@@ -36,6 +36,7 @@ libGormObjCHeaderParser_LIBRARIES_DEPEND_UPON += -lgnustep-gui -l$(FOUNDATION_LI
 #
 
 libGormObjCHeaderParser_HEADER_FILES= \
+GormObjCHeaderParser.h \
 NSScanner+OCHeaderParser.h \
 OCClass.h \
 OCHeaderParser.h \

--- a/GormObjCHeaderParser/GormObjCHeaderParser.h
+++ b/GormObjCHeaderParser/GormObjCHeaderParser.h
@@ -1,0 +1,47 @@
+/* GormObjCHeaderParser.h
+*
+* Copyright (C) 2019 Free Software Foundation, Inc.
+*
+* Author:  Lars Sonchocky-Helldorf
+* Date:  01.11.19
+*
+* This file is part of GNUstep.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published by
+* the Free Software Foundation; either version 2.1 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
+*/
+
+#import <Foundation/Foundation.h>
+
+#ifndef GNUSTEP
+//! Project version number for GormObjCHeaderParser.
+FOUNDATION_EXPORT double GormObjCHeaderParserVersionNumber;
+
+//! Project version string for GormObjCHeaderParser.
+FOUNDATION_EXPORT const unsigned char GormObjCHeaderParserVersionString[];
+#endif
+
+#ifndef INCLUDED_GORMOBJCHEADERPARSER_H
+#define INCLUDED_GORMOBJCHEADERPARSER_H
+ 
+#include <GormObjCHeaderParser/NSScanner+OCHeaderParser.h>
+#include <GormObjCHeaderParser/OCClass.h>
+#include <GormObjCHeaderParser/OCHeaderParser.h>
+#include <GormObjCHeaderParser/OCIVar.h>
+#include <GormObjCHeaderParser/OCIVarDecl.h>
+#include <GormObjCHeaderParser/OCMethod.h>
+#include <GormObjCHeaderParser/ParserFunctions.h>
+
+#endif
+

--- a/GormObjCHeaderParser/NSScanner+OCHeaderParser.h
+++ b/GormObjCHeaderParser/NSScanner+OCHeaderParser.h
@@ -23,7 +23,7 @@
  */
 
 
-#include <Foundation/NSScanner.h>
+#include <Foundation/Foundation.h>
 
 #ifndef INCLUDED_NSScanner_OCHeaderParser_h
 #define INCLUDED_NSScanner_OCHeaderParser_h

--- a/GormObjCHeaderParser/NSScanner+OCHeaderParser.m
+++ b/GormObjCHeaderParser/NSScanner+OCHeaderParser.m
@@ -24,6 +24,7 @@
 
 
 #include <Foundation/Foundation.h>
+
 #include <GormObjCHeaderParser/NSScanner+OCHeaderParser.h>
 
 @implementation NSScanner (OCHeaderParser)

--- a/GormObjCHeaderParser/OCClass.h
+++ b/GormObjCHeaderParser/OCClass.h
@@ -22,7 +22,7 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#include <Foundation/NSObject.h>
+#include <Foundation/Foundation.h>
 
 #ifndef INCLUDED_OCClass_h
 #define INCLUDED_OCClass_h

--- a/GormObjCHeaderParser/OCClass.m
+++ b/GormObjCHeaderParser/OCClass.m
@@ -22,11 +22,8 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+#include <Foundation/Foundation.h>
 
-#include <Foundation/NSString.h>
-#include <Foundation/NSArray.h>
-#include <Foundation/NSScanner.h>
-#include <Foundation/NSCharacterSet.h>
 #include <GormObjCHeaderParser/OCClass.h>
 #include <GormObjCHeaderParser/OCMethod.h>
 #include <GormObjCHeaderParser/OCIVar.h>

--- a/GormObjCHeaderParser/OCHeaderParser.h
+++ b/GormObjCHeaderParser/OCHeaderParser.h
@@ -22,7 +22,7 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#include <Foundation/NSObject.h>
+#include <Foundation/Foundation.h>
 
 #ifndef INCLUDED_OCHeaderParser_h
 #define INCLUDED_OCHeaderParser_h

--- a/GormObjCHeaderParser/OCHeaderParser.m
+++ b/GormObjCHeaderParser/OCHeaderParser.m
@@ -24,6 +24,7 @@
 
 
 #include <Foundation/Foundation.h>
+
 #include <GormObjCHeaderParser/OCHeaderParser.h>
 #include <GormObjCHeaderParser/OCClass.h>
 #include <GormObjCHeaderParser/NSScanner+OCHeaderParser.h>

--- a/GormObjCHeaderParser/OCIVar.h
+++ b/GormObjCHeaderParser/OCIVar.h
@@ -22,7 +22,7 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#include <Foundation/NSObject.h>
+#include <Foundation/Foundation.h>
 
 #ifndef INCLUDED_OCIVar_h
 #define INCLUDED_OCIVar_h

--- a/GormObjCHeaderParser/OCIVar.m
+++ b/GormObjCHeaderParser/OCIVar.m
@@ -24,6 +24,7 @@
 
 
 #include <Foundation/Foundation.h>
+
 #include <GormObjCHeaderParser/OCIVar.h>
 #include <GormObjCHeaderParser/NSScanner+OCHeaderParser.h>
 #include <GormObjCHeaderParser/ParserFunctions.h>

--- a/GormObjCHeaderParser/OCIVarDecl.h
+++ b/GormObjCHeaderParser/OCIVarDecl.h
@@ -22,7 +22,7 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#include <Foundation/NSObject.h>
+#include <Foundation/Foundation.h>
 
 #ifndef INCLUDED_OCIVarDecl_h
 #define INCLUDED_OCIVarDecl_h

--- a/GormObjCHeaderParser/OCIVarDecl.m
+++ b/GormObjCHeaderParser/OCIVarDecl.m
@@ -24,6 +24,7 @@
 
 
 #include <Foundation/Foundation.h>
+
 #include <GormObjCHeaderParser/OCIVar.h>
 #include <GormObjCHeaderParser/OCIVarDecl.h>
 #include <GormObjCHeaderParser/NSScanner+OCHeaderParser.h>

--- a/GormObjCHeaderParser/OCMethod.h
+++ b/GormObjCHeaderParser/OCMethod.h
@@ -22,7 +22,7 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-#include <Foundation/NSObject.h>
+#include <Foundation/Foundation.h>
 
 #ifndef INCLUDED_OCMethod_h
 #define INCLUDED_OCMethod_h

--- a/GormObjCHeaderParser/OCMethod.m
+++ b/GormObjCHeaderParser/OCMethod.m
@@ -24,6 +24,7 @@
 
 
 #include <Foundation/Foundation.h>
+
 #include <GormObjCHeaderParser/OCMethod.h>
 #include <GormObjCHeaderParser/NSScanner+OCHeaderParser.h>
 

--- a/GormObjCHeaderParser/ParserFunctions.h
+++ b/GormObjCHeaderParser/ParserFunctions.h
@@ -25,7 +25,7 @@
 #ifndef INCLUDED_ParserFunctions_h
 #define INCLUDED_ParserFunctions_h
 
-#include <Foundation/NSString.h>
+#include <Foundation/Foundation.h>
 
 BOOL lookAhead(NSString *stringToScan, NSString *stringToFind);
 BOOL lookAheadForToken(NSString *stringToScan, NSString *stringToFind);

--- a/GormObjCHeaderParser/ParserFunctions.m
+++ b/GormObjCHeaderParser/ParserFunctions.m
@@ -23,6 +23,7 @@
  */
 
 #include <Foundation/Foundation.h>
+
 #include "ParserFunctions.h"
 
 BOOL lookAhead(NSString *stringToScan, NSString *stringToFind)

--- a/GormPrefs/GNUmakefile
+++ b/GormPrefs/GNUmakefile
@@ -38,6 +38,7 @@ GormPrefs_LIBRARIES_DEPEND_UPON += -lgnustep-gui -l$(FOUNDATION_LIBRARY_NAME)
 #
 
 GormPrefs_HEADER_FILES= \
+GormPrefs.h \
 GormGeneralPref.h \
 GormGuidelinePref.h \
 GormHeadersPref.h \

--- a/GormPrefs/GormGeneralPref.h
+++ b/GormPrefs/GormGeneralPref.h
@@ -1,8 +1,8 @@
 #ifndef INCLUDED_GormGeneralPref_h
 #define INCLUDED_GormGeneralPref_h
 
-#include <Foundation/NSObject.h>
-#include <AppKit/NSView.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
 
 @interface GormGeneralPref : NSObject
 {

--- a/GormPrefs/GormGeneralPref.m
+++ b/GormPrefs/GormGeneralPref.m
@@ -22,17 +22,13 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
+
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
+#include <GormCore/GormCore.h>
+
 #include "GormGeneralPref.h"
-
-#include <Foundation/NSUserDefaults.h>
-#include <Foundation/NSNotification.h>
-
-#include <AppKit/NSButtonCell.h>
-#include <AppKit/NSNibLoading.h>
-#include <AppKit/NSWindow.h>
-#include <AppKit/NSMatrix.h>
-
-#include <GormCore/GormClassEditor.h>
 
 static NSString *BACKUPFILE=@"BackupFile";
 static NSString *INTTYPE=@"ClassViewType";

--- a/GormPrefs/GormGuidelinePref.h
+++ b/GormPrefs/GormGuidelinePref.h
@@ -25,9 +25,8 @@
 #ifndef INCLUDED_GormGuidelinePref_h
 #define INCLUDED_GormGuidelinePref_h
 
-#include <Foundation/NSObject.h>
-#include <Foundation/NSArray.h>
-#include <AppKit/NSView.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
 
 @class NSWindow;
 

--- a/GormPrefs/GormGuidelinePref.m
+++ b/GormPrefs/GormGuidelinePref.m
@@ -1,11 +1,10 @@
-#include "GormGuidelinePref.h"
-#include <GormCore/GormFunctions.h>
 
-#include <Foundation/NSUserDefaults.h>
-#include <AppKit/NSWindow.h>
-#include <AppKit/NSNibLoading.h>
-#include <AppKit/NSColorWell.h>
-#include <AppKit/NSColor.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
+#include <GormCore/GormCore.h>
+
+#include "GormGuidelinePref.h"
 
 @implementation GormGuidelinePref
 

--- a/GormPrefs/GormHeadersPref.h
+++ b/GormPrefs/GormHeadersPref.h
@@ -1,9 +1,8 @@
 #ifndef INCLUDED_GormHeadersPref_h
 #define INCLUDED_GormHeadersPref_h
 
-#include <Foundation/NSObject.h>
-#include <Foundation/NSArray.h>
-#include <AppKit/NSView.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
 
 @interface GormHeadersPref : NSObject
 {

--- a/GormPrefs/GormHeadersPref.m
+++ b/GormPrefs/GormHeadersPref.m
@@ -1,13 +1,8 @@
+
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
 #include "GormHeadersPref.h"
-
-#include <Foundation/NSUserDefaults.h>
-
-#include <AppKit/NSButton.h>
-#include <AppKit/NSTableView.h>
-#include <AppKit/NSWindow.h>
-#include <AppKit/NSNibLoading.h>
-#include <AppKit/NSOpenPanel.h>
-#include <AppKit/NSStringDrawing.h>
 
 // data source...
 @interface HeaderDataSource : NSObject

--- a/GormPrefs/GormPalettesPref.h
+++ b/GormPrefs/GormPalettesPref.h
@@ -1,9 +1,8 @@
 #ifndef INCLUDED_GormPalettesPref_h
 #define INCLUDED_GormPalettesPref_h
 
-#include <Foundation/NSObject.h>
-#include <Foundation/NSArray.h>
-#include <AppKit/NSView.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
 
 @interface GormPalettesPref : NSObject
 {

--- a/GormPrefs/GormPalettesPref.m
+++ b/GormPrefs/GormPalettesPref.m
@@ -22,11 +22,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <Foundation/NSUserDefaults.h>
-#include <AppKit/NSWindow.h>
-#include <AppKit/NSNibLoading.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
 
-#include <GormCore/GormPrivate.h>
+#include <GormCore/GormCore.h>
+
 #include "GormPalettesPref.h"
 
 @class NSTableView;

--- a/GormPrefs/GormPluginsPref.h
+++ b/GormPrefs/GormPluginsPref.h
@@ -1,9 +1,8 @@
 #ifndef INCLUDED_GormPluginsPref_h
 #define INCLUDED_GormPluginsPref_h
 
-#include <Foundation/NSObject.h>
-#include <Foundation/NSArray.h>
-#include <AppKit/NSView.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
 
 @interface GormPluginsPref : NSObject
 {

--- a/GormPrefs/GormPluginsPref.m
+++ b/GormPrefs/GormPluginsPref.m
@@ -22,12 +22,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <Foundation/NSUserDefaults.h>
-#include <AppKit/NSWindow.h>
-#include <AppKit/NSNibLoading.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
 
-#include <GormCore/GormPrivate.h>
-#include <GormCore/GormPluginManager.h>
+#include <GormCore/GormCore.h>
+
 #include "GormPluginsPref.h"
 
 @class NSTableView;

--- a/GormPrefs/GormPrefController.h
+++ b/GormPrefs/GormPrefController.h
@@ -26,8 +26,8 @@
 #ifndef INCLUDED_GormPrefController_h
 #define INCLUDED_GormPrefController_h
 
-#include <Foundation/NSObject.h>
-#include <AppKit/NSWindowController.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
 
 @interface GormPrefController : NSObject
 {

--- a/GormPrefs/GormPrefController.m
+++ b/GormPrefs/GormPrefController.m
@@ -1,3 +1,5 @@
+#include <AppKit/AppKit.h>
+
 #include "GormPrefController.h"
 #include "GormGeneralPref.h"
 #include "GormHeadersPref.h"
@@ -5,11 +7,6 @@
 #include "GormPalettesPref.h"
 #include "GormPluginsPref.h"
 #include "GormGuidelinePref.h"
-
-#include <AppKit/NSBox.h>
-#include <AppKit/NSPopUpButton.h>
-#include <AppKit/NSNibLoading.h>
-#include <AppKit/NSWindow.h>
 
 @implementation GormPrefController
 

--- a/GormPrefs/GormPrefs.h
+++ b/GormPrefs/GormPrefs.h
@@ -1,0 +1,46 @@
+/* GormPrefs.h
+*
+* Copyright (C) 2019 Free Software Foundation, Inc.
+*
+* Author:  Lars Sonchocky-Helldorf
+* Date:  01.11.19
+*
+* This file is part of GNUstep.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published by
+* the Free Software Foundation; either version 2.1 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
+*/
+
+#import <Foundation/Foundation.h>
+
+#ifndef GNUSTEP
+//! Project version number for GormPrefs.
+FOUNDATION_EXPORT double GormPrefsVersionNumber;
+
+//! Project version string for GormPrefs.
+FOUNDATION_EXPORT const unsigned char GormPrefsVersionString[];
+#endif
+
+#ifndef INCLUDED_GORMPREFS_H
+#define INCLUDED_GORMPREFS_H
+ 
+#include <GormPrefs/GormGeneralPref.h>
+#include <GormPrefs/GormGuidelinePref.h>
+#include <GormPrefs/GormHeadersPref.h>
+#include <GormPrefs/GormPalettesPref.h>
+#include <GormPrefs/GormPluginsPref.h>
+#include <GormPrefs/GormPrefController.h>
+#include <GormPrefs/GormShelfPref.h>
+
+#endif

--- a/GormPrefs/GormShelfPref.h
+++ b/GormPrefs/GormShelfPref.h
@@ -29,8 +29,8 @@
 #ifndef GORMSHELFPREF_H
 #define GORMSHELFPREF_H
 
-#include <AppKit/NSView.h>
-#include <Foundation/NSObject.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
 
 typedef enum { 
 	leftarrow,

--- a/GormPrefs/GormShelfPref.m
+++ b/GormPrefs/GormShelfPref.m
@@ -28,8 +28,9 @@
 
 #include <Foundation/Foundation.h>
 #include <AppKit/AppKit.h>
-#include <GormCore/GormFunctions.h>
-#include <GormCore/GormPrivate.h>
+
+#include <GormCore/GormCore.h>
+
 #include "GormShelfPref.h"
 
 #define BOX_W 197

--- a/Palettes/0Menus/.cvsignore
+++ b/Palettes/0Menus/.cvsignore
@@ -1,6 +1,0 @@
-*.app
-*.debug
-*.profile
-*.palette
-*obj
-.gdbinit

--- a/Palettes/0Menus/GormMenuAttributesInspector.h
+++ b/Palettes/0Menus/GormMenuAttributesInspector.h
@@ -33,7 +33,7 @@
 #ifndef INCLUDED_GormMenuAttributesInspector_h_
 #define INCLUDED_GormMenuAttributesInspector_h_
 
-#include <InterfaceBuilder/IBInspector.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSButton;
 @class NSMatrix;

--- a/Palettes/0Menus/GormMenuAttributesInspector.m
+++ b/Palettes/0Menus/GormMenuAttributesInspector.m
@@ -32,17 +32,14 @@
   Author : Fabien Vallon <fabien@sonappart.net>
 */
 
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
+#include <GormCore/GormCore.h>
+
 #include "GormMenuAttributesInspector.h"
 #include "GormNSMenu.h"
 
-#include <Foundation/NSNotification.h>
-
-#include <GormCore/GormDocument.h>
-
-#include <AppKit/NSButton.h>
-#include <AppKit/NSMatrix.h>
-#include <AppKit/NSNibLoading.h>
-#include <AppKit/NSTextField.h>
 
 
 #define WINDOWSMENUTAG         0

--- a/Palettes/0Menus/GormMenuEditor.m
+++ b/Palettes/0Menus/GormMenuEditor.m
@@ -23,8 +23,9 @@
  */
 
 #include <AppKit/AppKit.h>
+
 #include <InterfaceBuilder/InterfaceBuilder.h>
-#include <GormCore/GormFunctions.h>
+#include <GormCore/GormCore.h>
 
 /*
  * This method will allow us to check if the menu is

--- a/Palettes/0Menus/GormMenuInspectors.m
+++ b/Palettes/0Menus/GormMenuInspectors.m
@@ -25,9 +25,9 @@
  */
 
 #include <AppKit/AppKit.h>
+
 #include <InterfaceBuilder/InterfaceBuilder.h>
-#include <GormCore/GormPrivate.h>
-#include <GormCore/GormDocument.h>
+#include <GormCore/GormCore.h>
 
 @interface GormMenuAttributesInspector : IBInspector
 {

--- a/Palettes/0Menus/GormMenuItemAttributesInspector.h
+++ b/Palettes/0Menus/GormMenuItemAttributesInspector.h
@@ -34,7 +34,7 @@
 #ifndef INCLUDED_GormMenuItemAttributesInspector_h_
 #define INCLUDED_GormMenuItemAttributesInspector_h_
 
-#include <InterfaceBuilder/IBInspector.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSTextField, NSPopUpButton;
 

--- a/Palettes/0Menus/GormMenuItemAttributesInspector.m
+++ b/Palettes/0Menus/GormMenuItemAttributesInspector.m
@@ -30,9 +30,10 @@
   Author : Fabien Vallon <fabien@sonappart.net>
 */
 
-#include "GormMenuItemAttributesInspector.h"
 #include <Foundation/Foundation.h>
 #include <AppKit/AppKit.h>
+
+#include "GormMenuItemAttributesInspector.h"
 
 const unichar up[]={NSUpArrowFunctionKey};
 const unichar dn[]={NSDownArrowFunctionKey};

--- a/Palettes/0Menus/GormNSMenu.m
+++ b/Palettes/0Menus/GormNSMenu.m
@@ -22,12 +22,13 @@
    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
 */
 
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
+
 #include "GormNSMenuView.h"
 #include "GormNSMenu.h"
-#include <Foundation/NSEnumerator.h>
-#include <AppKit/NSPopUpButton.h>
-#include <AppKit/NSPopUpButtonCell.h>
-#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @interface GormNSMenuWindow : NSPanel
 @end

--- a/Palettes/0Menus/GormNSMenuView.m
+++ b/Palettes/0Menus/GormNSMenuView.m
@@ -25,6 +25,7 @@
 
 #include <Foundation/Foundation.h>
 #include <AppKit/AppKit.h>
+
 #include "GormNSMenuView.h"
 
 @implementation GormNSMenuView

--- a/Palettes/0Menus/MenusPalette.m
+++ b/Palettes/0Menus/MenusPalette.m
@@ -26,7 +26,9 @@
 */
 #include <Foundation/Foundation.h>
 #include <AppKit/AppKit.h>
+
 #include <InterfaceBuilder/InterfaceBuilder.h>
+
 #include "GormNSMenu.h"
 
 @interface GormMenuMaker : NSObject <NSCoding>

--- a/Palettes/0Menus/inspectors.m
+++ b/Palettes/0Menus/inspectors.m
@@ -25,6 +25,7 @@
  */
 
 #include <AppKit/AppKit.h>
+
 #include <InterfaceBuilder/InterfaceBuilder.h>
 
 @implementation	NSMenu (IBObjectAdditions)

--- a/Palettes/1Windows/.cvsignore
+++ b/Palettes/1Windows/.cvsignore
@@ -1,6 +1,0 @@
-*.app
-*.debug
-*.profile
-*.palette
-*obj
-.gdbinit

--- a/Palettes/1Windows/GormDrawerAttributesInspector.h
+++ b/Palettes/1Windows/GormDrawerAttributesInspector.h
@@ -26,7 +26,8 @@
 /* All Rights reserved */
 
 #include <AppKit/AppKit.h>
-#include <InterfaceBuilder/IBInspector.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @interface GormDrawerAttributesInspector : IBInspector
 {

--- a/Palettes/1Windows/GormDrawerAttributesInspector.m
+++ b/Palettes/1Windows/GormDrawerAttributesInspector.m
@@ -26,6 +26,7 @@
 /* All Rights reserved */
 
 #include <AppKit/AppKit.h>
+
 #include "GormDrawerAttributesInspector.h"
 
 @implementation GormDrawerAttributesInspector

--- a/Palettes/1Windows/GormWindowAttributesInspector.h
+++ b/Palettes/1Windows/GormWindowAttributesInspector.h
@@ -37,7 +37,7 @@
 #define	INCLUDED_GormWindowAttributesInspector_h
 
 
-#include <InterfaceBuilder/IBInspector.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSButton;
 @class NSColorWell;

--- a/Palettes/1Windows/GormWindowAttributesInspector.m
+++ b/Palettes/1Windows/GormWindowAttributesInspector.m
@@ -32,12 +32,11 @@
   Author : Fabien Vallon <fabien@sonappart.net>
 */
 
-#include "GormWindowAttributesInspector.h"
-
-#include <GormCore/GormNSWindow.h>
-#include <GormCore/GormDocument.h>
-#include <GormCore/NSColorWell+GormExtensions.h>
 #include <AppKit/NSNibLoading.h>
+
+#include <GormCore/GormCore.h>
+
+#include "GormWindowAttributesInspector.h"
 
 @implementation GormWindowAttributesInspector
 

--- a/Palettes/1Windows/GormWindowSizeInspector.h
+++ b/Palettes/1Windows/GormWindowSizeInspector.h
@@ -35,7 +35,7 @@
 #ifndef	INCLUDED_GormWindowSizeInspector_h
 #define	INCLUDED_GormWindowSizeInspector_h
 
-#include <InterfaceBuilder/IBInspector.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSButton;
 @class NSForm;

--- a/Palettes/1Windows/GormWindowSizeInspector.m
+++ b/Palettes/1Windows/GormWindowSizeInspector.m
@@ -32,17 +32,12 @@
   Author : Fabien Vallon <fabien@sonappart.net>
 */
 
-#include "GormWindowSizeInspector.h"
-
-#include <Foundation/NSNotification.h>
-
-#include <AppKit/NSButton.h>
-#include <AppKit/NSForm.h>
-#include <AppKit/NSNibLoading.h>
-#include <AppKit/NSPanel.h>
-#include <AppKit/NSWindow.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
 
 #include <GNUstepGUI/GSGormLoading.h>
+
+#include "GormWindowSizeInspector.h"
 
 /*
   IBObjectAdditions category for NSPanel

--- a/Palettes/1Windows/WindowsPalette.h
+++ b/Palettes/1Windows/WindowsPalette.h
@@ -23,7 +23,7 @@
    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
 */
 
-#include <InterfaceBuilder/IBInspector.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @interface WindowsPalette: IBPalette
 @end

--- a/Palettes/1Windows/WindowsPalette.m
+++ b/Palettes/1Windows/WindowsPalette.m
@@ -23,14 +23,8 @@
    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
 */
 
-#include <InterfaceBuilder/IBApplicationAdditions.h>
-#include <InterfaceBuilder/IBInspector.h>
-#include <InterfaceBuilder/IBPalette.h>
-
-#include <GormCore/GormDocument.h>
-#include <GormCore/NSColorWell+GormExtensions.h>
-#include <GormCore/GormNSPanel.h>
-#include <GormCore/GormNSWindow.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
+#include <GormCore/GormCore.h>
 
 #include "GormWindowSizeInspector.h"
 #include "WindowsPalette.h"

--- a/Palettes/1Windows/inspectors.m
+++ b/Palettes/1Windows/inspectors.m
@@ -25,7 +25,9 @@
  */
 
 #include <AppKit/AppKit.h>
+
 #include <InterfaceBuilder/InterfaceBuilder.h>
+
 #include "WindowsPalette.h"
 /*
   IBObjectAdditions category for NSPanel 

--- a/Palettes/2Controls/.cvsignore
+++ b/Palettes/2Controls/.cvsignore
@@ -1,6 +1,0 @@
-*.app
-*.debug
-*.profile
-*.palette
-*obj
-.gdbinit

--- a/Palettes/2Controls/ControlsPalette.m
+++ b/Palettes/2Controls/ControlsPalette.m
@@ -23,13 +23,10 @@
    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
 */
 
-#include <InterfaceBuilder/IBPalette.h>
-#include <InterfaceBuilder/IBViewResourceDragging.h>
-#include <AppKit/NSWindow.h>
-#include <AppKit/NSPopUpButton.h>
-#include <AppKit/NSPasteboard.h>
-#include <AppKit/NSImage.h>
-#include <AppKit/NSSound.h>
+#include <AppKit/AppKit.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
+
 #include "GormNSPopUpButton.h"
 
 @interface ControlsPalette: IBPalette <IBViewResourceDraggingDelegates>

--- a/Palettes/2Controls/GormBoxAttributesInspector.h
+++ b/Palettes/2Controls/GormBoxAttributesInspector.h
@@ -37,7 +37,7 @@
 #ifndef	INCLUDED_GormBoxAttributesInspector_h
 #define	INCLUDED_GormBoxAttributesInspector_h
 
-#include <InterfaceBuilder/IBInspector.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSButton;
 @class NSColorWell;

--- a/Palettes/2Controls/GormBoxAttributesInspector.m
+++ b/Palettes/2Controls/GormBoxAttributesInspector.m
@@ -33,19 +33,12 @@
   Author : Fabien Vallon <fabien@sonappart.net>
 */
 
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
+#include <GormCore/GormCore.h>
+
 #include "GormBoxAttributesInspector.h"
-
-#include <GormCore/NSColorWell+GormExtensions.h>
-
-#include <Foundation/NSNotification.h>
-
-#include <AppKit/NSButton.h>
-#include <AppKit/NSBox.h>
-#include <AppKit/NSForm.h>
-#include <AppKit/NSMatrix.h>
-#include <AppKit/NSNibLoading.h>
-#include <AppKit/NSSlider.h>
-#include <AppKit/NSTextFieldCell.h>
 
 /* This macro makes sure that the string contains a value, even if @"" */
 #define VSTR(str) ({id _str = (id)str; (_str) ? (id)_str : (id)(@"");})

--- a/Palettes/2Controls/GormButtonAttributesInspector.h
+++ b/Palettes/2Controls/GormButtonAttributesInspector.h
@@ -35,7 +35,7 @@
 #ifndef	INCLUDED_GormButtonAttributesInspector_h
 #define	INCLUDED_GormButtonAttributesInspector_h
 
-#include <InterfaceBuilder/IBInspector.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSForm;
 @class NSMatrix;

--- a/Palettes/2Controls/GormButtonAttributesInspector.m
+++ b/Palettes/2Controls/GormButtonAttributesInspector.m
@@ -27,6 +27,7 @@
 
 #include <Foundation/Foundation.h>
 #include <AppKit/AppKit.h>
+
 #include <InterfaceBuilder/InterfaceBuilder.h>
 
 #include "GormButtonAttributesInspector.h"

--- a/Palettes/2Controls/GormButtonEditor.h
+++ b/Palettes/2Controls/GormButtonEditor.h
@@ -24,7 +24,7 @@
 #ifndef	INCLUDED_GormButtonEditor_h
 #define	INCLUDED_GormButtonEditor_h
 
-#include <GormCore/GormControlEditor.h>
+#include <GormCore/GormCore.h>
 
 @class NSTextView;
 

--- a/Palettes/2Controls/GormButtonEditor.m
+++ b/Palettes/2Controls/GormButtonEditor.m
@@ -22,10 +22,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <InterfaceBuilder/InterfaceBuilder.h>
 #include <AppKit/AppKit.h>
-#include <GormCore/GormPrivate.h>
-#include <GormCore/GormViewWithSubviewsEditor.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
+#include <GormCore/GormCore.h>
+
 #include "GormButtonEditor.h"
 
 #define _EO ((NSButton *)_editedObject)

--- a/Palettes/2Controls/GormCellAttributesInspector.h
+++ b/Palettes/2Controls/GormCellAttributesInspector.h
@@ -36,7 +36,7 @@
 #ifndef INCLUDED_GormCellAttributesInspector_h
 #define INCLUDED_GormCellAttributesInspector_h
 
-#include <InterfaceBuilder/IBInspector.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSButton;
 @class NSForm;

--- a/Palettes/2Controls/GormCellAttributesInspector.m
+++ b/Palettes/2Controls/GormCellAttributesInspector.m
@@ -33,14 +33,10 @@
   Author : Fabien Vallon <fabien@sonappart.net>
 */
 
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
 #include "GormCellAttributesInspector.h"
-
-#include <Foundation/NSNotification.h>
-
-#include <AppKit/NSButton.h>
-#include <AppKit/NSCell.h>
-#include <AppKit/NSForm.h>
-#include <AppKit/NSNibLoading.h>
 
 /*
   IBObjectAdditions category

--- a/Palettes/2Controls/GormColorWellAttributesInspector.h
+++ b/Palettes/2Controls/GormColorWellAttributesInspector.h
@@ -36,7 +36,7 @@
 #ifndef	INCLUDED_GormColorWellAttributesInspector_h
 #define	INCLUDED_GormColorWellAttributesInspector_h
 
-#include <InterfaceBuilder/IBInspector.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSButton;
 @class NSColorWell;

--- a/Palettes/2Controls/GormColorWellAttributesInspector.m
+++ b/Palettes/2Controls/GormColorWellAttributesInspector.m
@@ -33,17 +33,12 @@
   Author : Fabien Vallon <fabien@sonappart.net>
 */
 
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
+#include <GormCore/GormCore.h>
 
 #include "GormColorWellAttributesInspector.h"
-
-#include <GormCore/NSColorWell+GormExtensions.h>
-
-#include <Foundation/NSNotification.h>
-
-#include <AppKit/NSButton.h>
-#include <AppKit/NSNibLoading.h>
-#include <AppKit/NSTextField.h>
-
 
 
 /*

--- a/Palettes/2Controls/GormFormAttributesInspector.h
+++ b/Palettes/2Controls/GormFormAttributesInspector.h
@@ -36,7 +36,7 @@
 #ifndef INCLUDED_GormFormAttributesInspector_h
 #define INCLUDED_GormFormAttributesInspector_h
 
-#include <InterfaceBuilder/IBInspector.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSButton;
 @class NSColorWell;

--- a/Palettes/2Controls/GormFormAttributesInspector.m
+++ b/Palettes/2Controls/GormFormAttributesInspector.m
@@ -33,18 +33,12 @@
   Author : Fabien Vallon <fabien@sonappart.net>
 */
 
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
+#include <GormCore/GormCore.h>
+
 #include "GormFormAttributesInspector.h"
-#include <GormCore/NSColorWell+GormExtensions.h>
-
-#include <Foundation/NSNotification.h>
-#include <Foundation/NSDebug.h>
-
-#include <AppKit/NSButton.h>
-#include <AppKit/NSForm.h>
-#include <AppKit/NSMatrix.h>
-#include <AppKit/NSNibLoading.h>
-#include <AppKit/NSFormCell.h>
-#include <AppKit/NSStepper.h>
 
 /*
   IBObjectAdditions category

--- a/Palettes/2Controls/GormMatrixAttributesInspector.h
+++ b/Palettes/2Controls/GormMatrixAttributesInspector.h
@@ -34,7 +34,7 @@
 #ifndef INCLUDED_GormMatrixAttributesInspector_h
 #define INCLUDED_GormMatrixAttributesInspector_h
 
-#include <InterfaceBuilder/IBInspector.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSButton;
 @class NSColorWell;

--- a/Palettes/2Controls/GormMatrixAttributesInspector.m
+++ b/Palettes/2Controls/GormMatrixAttributesInspector.m
@@ -31,18 +31,13 @@
   Author : Fabien Vallon <fabien@sonappart.net>
 */
 
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
+#include <GormCore/GormCore.h>
 
 #include "GormMatrixAttributesInspector.h"
 
-#include <GormCore/NSColorWell+GormExtensions.h>
-
-#include <Foundation/NSNotification.h>
-
-#include <AppKit/NSButton.h>
-#include <AppKit/NSForm.h>
-#include <AppKit/NSMatrix.h>
-#include <AppKit/NSNibLoading.h>
-#include <AppKit/NSStepper.h>
 
 
 @implementation	NSMatrix (IBObjectAdditions)

--- a/Palettes/2Controls/GormNSPopUpButton.m
+++ b/Palettes/2Controls/GormNSPopUpButton.m
@@ -1,4 +1,5 @@
-#include <GormCore/GormPrivate.h>
+#include <GormCore/GormCore.h>
+
 #include "GormNSPopUpButton.h"
 
 Class _gormnspopupbuttonCellClass = 0;

--- a/Palettes/2Controls/GormPopUpButtonAttributesInspector.h
+++ b/Palettes/2Controls/GormPopUpButtonAttributesInspector.h
@@ -35,7 +35,7 @@
 #ifndef	INCLUDED_GormPopUpButtonAttributesInspector_h
 #define	INCLUDED_GormPopUpButtonAttributesInspector_h
 
-#include <InterfaceBuilder/IBInspector.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSButton;
 @class NSForm;

--- a/Palettes/2Controls/GormPopUpButtonAttributesInspector.m
+++ b/Palettes/2Controls/GormPopUpButtonAttributesInspector.m
@@ -31,14 +31,10 @@
   Author : Fabien Vallon <fabien@sonappart.net>
 */
 
-#include "GormPopUpButtonAttributesInspector.h"
-
 #include <Foundation/Foundation.h>
-#include <AppKit/NSButton.h>
-#include <AppKit/NSForm.h>
-#include <AppKit/NSMatrix.h>
-#include <AppKit/NSNibLoading.h>
-#include <AppKit/NSPopUpButton.h>
+#include <AppKit/AppKit.h>
+
+#include "GormPopUpButtonAttributesInspector.h"
 
 /*
   IBObjectAdditions category

--- a/Palettes/2Controls/GormPopUpButtonEditor.m
+++ b/Palettes/2Controls/GormPopUpButtonEditor.m
@@ -1,7 +1,7 @@
 #include <AppKit/AppKit.h>
-#include <GormCore/GormPrivate.h>
-#include <GormCore/GormControlEditor.h>
-#include <GormCore/GormViewWithSubviewsEditor.h>
+
+#include <GormCore/GormCore.h>
+
 #include "GormNSPopUpButton.h"
 
 #define _EO ((NSPopUpButton *)_editedObject)

--- a/Palettes/2Controls/GormProgressIndicatorAttributesInspector.h
+++ b/Palettes/2Controls/GormProgressIndicatorAttributesInspector.h
@@ -35,7 +35,7 @@
 #ifndef	INCLUDED_GormProgressIndicatorAttributesInspector_h
 #define	INCLUDED_GormProgressIndicatorAttributesInspector_h
 
-#include <InterfaceBuilder/IBInspector.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSButton;
 @class NSTextField;

--- a/Palettes/2Controls/GormProgressIndicatorAttributesInspector.m
+++ b/Palettes/2Controls/GormProgressIndicatorAttributesInspector.m
@@ -31,14 +31,10 @@
   Author : Fabien Vallon <fabien@sonappart.net>
 */
 
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
 #include "GormProgressIndicatorAttributesInspector.h"
-
-#include <Foundation/NSNotification.h>
-
-#include <AppKit/NSButton.h>
-#include <AppKit/NSNibLoading.h>
-#include <AppKit/NSProgressIndicator.h>
-#include <AppKit/NSTextField.h>
 
 
 /*

--- a/Palettes/2Controls/GormSliderAttributesInspector.h
+++ b/Palettes/2Controls/GormSliderAttributesInspector.h
@@ -35,7 +35,7 @@
 #ifndef	INCLUDED_GormSliderAttributesInspector_h
 #define	INCLUDED_GormSliderAttributesInspector_h
 
-#include <InterfaceBuilder/IBInspector.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSButton;
 @class NSForm;

--- a/Palettes/2Controls/GormSliderAttributesInspector.m
+++ b/Palettes/2Controls/GormSliderAttributesInspector.m
@@ -31,14 +31,10 @@
   Author : Fabien Vallon <fabien@sonappart.net>
 */
 
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
 #include "GormSliderAttributesInspector.h"
-
-#include <Foundation/NSNotification.h>
-
-#include <AppKit/NSButton.h>
-#include <AppKit/NSForm.h>
-#include <AppKit/NSNibLoading.h>
-#include <AppKit/NSSlider.h>
 
 /* 
    IBObjectAdditions category

--- a/Palettes/2Controls/GormStepperAttributesInspector.h
+++ b/Palettes/2Controls/GormStepperAttributesInspector.h
@@ -35,7 +35,7 @@
 #ifndef	INCLUDED_GormStepperAttributesInspector_h
 #define	INCLUDED_GormStepperAttributesInspector_h
 
-#include <InterfaceBuilder/IBInspector.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSButton;
 @class NSTextField;

--- a/Palettes/2Controls/GormStepperAttributesInspector.m
+++ b/Palettes/2Controls/GormStepperAttributesInspector.m
@@ -31,12 +31,10 @@
   Author : Fabien Vallon <fabien@sonappart.net>
 */
 
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
 #include "GormStepperAttributesInspector.h"
-#include <Foundation/NSNotification.h>
-#include <AppKit/NSButton.h>
-#include <AppKit/NSNibLoading.h>
-#include <AppKit/NSStepper.h>
-#include <AppKit/NSTextField.h>
 
 // Some simple inspectors.
 @interface GormStepperCellAttributesInspector : GormStepperAttributesInspector

--- a/Palettes/2Controls/GormTextFieldAttributesInspector.h
+++ b/Palettes/2Controls/GormTextFieldAttributesInspector.h
@@ -35,7 +35,7 @@
 #ifndef	INCLUDED_GormTextFieldAttributesInspector_h
 #define	INCLUDED_GormTextFieldAttributesInspector_h
 
-#include <InterfaceBuilder/IBInspector.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSButton;
 @class NSColorWell;

--- a/Palettes/2Controls/GormTextFieldAttributesInspector.m
+++ b/Palettes/2Controls/GormTextFieldAttributesInspector.m
@@ -31,18 +31,12 @@
   Author : Fabien Vallon <fabien@sonappart.net>
 */
 
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
+#include <GormCore/GormCore.h>
 
 #include "GormTextFieldAttributesInspector.h"
-
-#include <GormCore/NSColorWell+GormExtensions.h>
-
-#include <Foundation/NSNotification.h>
-
-#include <AppKit/NSButton.h>
-#include <AppKit/NSForm.h>
-#include <AppKit/NSMatrix.h>
-#include <AppKit/NSNibLoading.h>
-#include <AppKit/NSTextField.h>
 
 
 /*

--- a/Palettes/2Controls/inspectors.m
+++ b/Palettes/2Controls/inspectors.m
@@ -24,6 +24,7 @@
 */
 
 #include <AppKit/AppKit.h>
+
 #include <InterfaceBuilder/InterfaceBuilder.h>
 
 #include "GormButtonAttributesInspector.h"

--- a/Palettes/3Containers/.cvsignore
+++ b/Palettes/3Containers/.cvsignore
@@ -1,6 +1,0 @@
-*.app
-*.debug
-*.profile
-*.palette
-*obj
-.gdbinit

--- a/Palettes/3Containers/ContainersPalette.m
+++ b/Palettes/3Containers/ContainersPalette.m
@@ -22,15 +22,14 @@
    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
 */
 #include <Foundation/Foundation.h>
-#include <AppKit/NSTableColumn.h>
-#include <AppKit/NSTabView.h>
-#include <AppKit/NSWindow.h>
-#include <AppKit/NSTabViewItem.h>
-#include <AppKit/NSScrollView.h>
+#include <AppKit/AppKit.h>
+
 #include <InterfaceBuilder/InterfaceBuilder.h>
+
 #include "GormNSBrowser.h"
 #include "GormNSTableView.h"
 #include "GormNSOutlineView.h"
+
 #include <math.h>
 
 

--- a/Palettes/3Containers/GormBrowserAttributesInspector.h
+++ b/Palettes/3Containers/GormBrowserAttributesInspector.h
@@ -34,7 +34,7 @@
 #ifndef INCLUDED_GormBrowserAttributesInspector_h
 #define INCLUDED_GormBrowserAttributesInspector_h
 
-#include <InterfaceBuilder/IBInspector.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSButton;
 @class NSForm;

--- a/Palettes/3Containers/GormBrowserAttributesInspector.m
+++ b/Palettes/3Containers/GormBrowserAttributesInspector.m
@@ -32,15 +32,10 @@
   Author : Fabien Vallon <fabien@sonappart.net>
 */
 
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
 #include "GormBrowserAttributesInspector.h"
-
-#include <Foundation/NSNotification.h>
-
-#include <AppKit/NSBrowser.h>
-#include <AppKit/NSButton.h>
-#include <AppKit/NSForm.h>
-#include <AppKit/NSNibLoading.h>
-#include <AppKit/NSTextField.h>
 
 @implementation GormBrowserAttributesInspector
 

--- a/Palettes/3Containers/GormNSBrowser.h
+++ b/Palettes/3Containers/GormNSBrowser.h
@@ -24,7 +24,7 @@
 #ifndef	INCLUDED_GormNSBrowser_h
 #define	INCLUDED_GormNSBrowser_h
 
-#include <AppKit/NSBrowser.h>
+#include <AppKit/AppKit.h>
 
 @interface GormNSBrowser : NSBrowser
 {

--- a/Palettes/3Containers/GormNSBrowser.m
+++ b/Palettes/3Containers/GormNSBrowser.m
@@ -22,9 +22,9 @@
    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
 */
 
-#include <Foundation/NSObject.h>
-#include <Foundation/NSDebug.h>
-#include <AppKit/NSBrowserCell.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
 #include "GormNSBrowser.h"
 
 /* --------------------------------------------------------------- 

--- a/Palettes/3Containers/GormNSOutlineView.h
+++ b/Palettes/3Containers/GormNSOutlineView.h
@@ -25,8 +25,7 @@
 #define	INCLUDED_GormNSOutlineView_h
 
 #include <Foundation/Foundation.h>
-#include <AppKit/NSColor.h>
-#include <AppKit/NSOutlineView.h>
+#include <AppKit/AppKit.h>
 
 @interface GormNSOutlineView : NSOutlineView
 {

--- a/Palettes/3Containers/GormNSOutlineView.m
+++ b/Palettes/3Containers/GormNSOutlineView.m
@@ -22,8 +22,9 @@
    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
 */
 
+#include <AppKit/AppKit.h>
+
 #include "GormNSOutlineView.h"
-#include <AppKit/NSTableColumn.h>
 
 /* --------------------------------------------------------------- 
  * NSTableView dataSource

--- a/Palettes/3Containers/GormNSTableView.h
+++ b/Palettes/3Containers/GormNSTableView.h
@@ -25,8 +25,7 @@
 #define	INCLUDED_GormNSTableView_h
 
 #include <Foundation/Foundation.h>
-#include <AppKit/NSColor.h>
-#include <AppKit/NSTableView.h>
+#include <AppKit/AppKit.h>
 
 @interface GormNSTableView : NSTableView
 {

--- a/Palettes/3Containers/GormNSTableView.m
+++ b/Palettes/3Containers/GormNSTableView.m
@@ -22,9 +22,11 @@
    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
 */
 
-#include <Foundation/NSObject.h>
-#include <InterfaceBuilder/IBApplicationAdditions.h>
-#include <AppKit/NSTableColumn.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
+
 #include "GormNSTableView.h"
 
 /* --------------------------------------------------------------- 

--- a/Palettes/3Containers/GormTabViewAttributesInspector.h
+++ b/Palettes/3Containers/GormTabViewAttributesInspector.h
@@ -34,7 +34,7 @@
 #ifndef	INCLUDED_GormTabViewAttributesInspector_h
 #define	INCLUDED_GormTabViewAttributesInspector_h
 
-#include <InterfaceBuilder/IBInspector.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSButton;
 @class NSForm;

--- a/Palettes/3Containers/GormTabViewAttributesInspector.m
+++ b/Palettes/3Containers/GormTabViewAttributesInspector.m
@@ -30,19 +30,13 @@
   Author : Fabien Vallon <fabien@sonappart.net>
 */
 
-#include "GormTabViewAttributesInspector.h"
 
-#include <Foundation/NSNotification.h>
-#include <AppKit/NSButton.h>
-#include <AppKit/NSForm.h>
-#include <AppKit/NSMatrix.h>
-#include <AppKit/NSNibLoading.h>
-#include <AppKit/NSStepper.h>
-#include <AppKit/NSTabView.h>
-#include <AppKit/NSTabViewItem.h>
-#include <AppKit/NSTextField.h>
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
 
 #include <InterfaceBuilder/InterfaceBuilder.h>
+
+#include "GormTabViewAttributesInspector.h"
 
 #define ORDERED_PREVIOUS 0
 #define ORDERED_NEXT     1

--- a/Palettes/3Containers/GormTabViewEditor.h
+++ b/Palettes/3Containers/GormTabViewEditor.h
@@ -24,8 +24,7 @@
 #ifndef	INCLUDED_GormTabViewEditor_h
 #define	INCLUDED_GormTabViewEditor_h
 
-#include <GormCore/GormViewWithSubviewsEditor.h>
-#include <GormCore/GormInternalViewEditor.h>
+#include <GormCore/GormCore.h>
 
 @interface GormTabViewEditor : GormViewWithSubviewsEditor
 {

--- a/Palettes/3Containers/GormTabViewEditor.m
+++ b/Palettes/3Containers/GormTabViewEditor.m
@@ -22,11 +22,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <InterfaceBuilder/IBObjectAdditions.h>
 #include <AppKit/AppKit.h>
 
-#include <GormCore/GormPrivate.h>
-#include <GormCore/GormViewKnobs.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
+#include <GormCore/GormCore.h>
 
 #include "GormTabViewEditor.h"
 

--- a/Palettes/3Containers/GormTableColumnAttributesInspector.h
+++ b/Palettes/3Containers/GormTableColumnAttributesInspector.h
@@ -35,7 +35,7 @@
 #ifndef	INCLUDED_GormTableColumnAttributesInspector_h
 #define	INCLUDED_GormTableColumnAttributesInspector_h
 
-#include <InterfaceBuilder/IBInspector.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSButton;
 @class NSMatrix;

--- a/Palettes/3Containers/GormTableColumnAttributesInspector.m
+++ b/Palettes/3Containers/GormTableColumnAttributesInspector.m
@@ -35,17 +35,11 @@
 */
 
 
-#import "GormTableColumnAttributesInspector.h"
-#import <GormCore/GormPrivate.h>
+#import <AppKit/AppKit.h>
 
-#import <AppKit/NSButton.h>
-#import <AppKit/NSMatrix.h>
-#import <AppKit/NSNibLoading.h>
-#import <AppKit/NSTextField.h>
-#import <AppKit/NSTableView.h>
-#import <AppKit/NSTableColumn.h>
-#import <AppKit/NSForm.h>
-#import <AppKit/NSPopUpButton.h>
+#import <GormCore/GormCore.h>
+
+#import "GormTableColumnAttributesInspector.h"
 
 /*
   IBObjectAdditions category

--- a/Palettes/3Containers/GormTableColumnSizeInspector.h
+++ b/Palettes/3Containers/GormTableColumnSizeInspector.h
@@ -34,7 +34,7 @@
 #ifndef INCLUDED_GormTableColumnnSizeInspector_h
 #define INCLUDED_GormTableColumnnSizeInspector_h
 
-#include <InterfaceBuilder/IBInspector.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSForm;
 

--- a/Palettes/3Containers/GormTableColumnSizeInspector.m
+++ b/Palettes/3Containers/GormTableColumnSizeInspector.m
@@ -31,13 +31,10 @@
   Author : Fabien Vallon <fabien@sonappart.net>
 */
 
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
 #include "GormTableColumnSizeInspector.h"
-
-#include <Foundation/NSNotification.h>
-
-#include <AppKit/NSForm.h>
-#include <AppKit/NSNibLoading.h>
-#include <AppKit/NSTableColumn.h>
 
 #define MINIMUMINDEX 0
 #define CURRENTINDEX 1

--- a/Palettes/3Containers/GormTableViewAttributesInspector.h
+++ b/Palettes/3Containers/GormTableViewAttributesInspector.h
@@ -33,7 +33,7 @@
 #ifndef	INCLUDED_GormTableViewAttributesInspector_h
 #define	INCLUDED_GormTableViewAttributesInspector_h
 
-#include <InterfaceBuilder/IBInspector.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSButton;
 @class NSColorWell;

--- a/Palettes/3Containers/GormTableViewAttributesInspector.m
+++ b/Palettes/3Containers/GormTableViewAttributesInspector.m
@@ -29,17 +29,14 @@
   Clean up
   Author : Fabien Vallon <fabien@sonappart.net>
 */
+
+#import <Foundation/Foundation.h>
+#import <AppKit/AppKit.h>
+
+#import <GormCore/GormCore.h>
+
 #import "GormTableViewAttributesInspector.h"
 #import "GormNSTableView.h"
-#import <GormCore/NSColorWell+GormExtensions.h>
-#import <GormCore/GormPrivate.h>
-#import <Foundation/NSNotification.h>
-#import <Foundation/NSSortDescriptor.h>
-#import <AppKit/NSButton.h>
-#import <AppKit/NSColorWell.h>
-#import <AppKit/NSForm.h>
-#import <AppKit/NSMatrix.h>
-#import <AppKit/NSNibLoading.h>
 
 
 @implementation GormTableViewAttributesInspector

--- a/Palettes/3Containers/GormTableViewEditor.h
+++ b/Palettes/3Containers/GormTableViewEditor.h
@@ -24,7 +24,7 @@
 #ifndef	INCLUDED_GormTableViewEditor_h
 #define	INCLUDED_GormTableViewEditor_h
 
-#include <GormCore/GormViewWithSubviewsEditor.h>
+#include <GormCore/GormCore.h>
 
 @class GormNSTableView;
 

--- a/Palettes/3Containers/GormTableViewEditor.m
+++ b/Palettes/3Containers/GormTableViewEditor.m
@@ -23,10 +23,12 @@
  */
 
 #include <AppKit/AppKit.h>
+
 #include <InterfaceBuilder/InterfaceBuilder.h>
+#include <GormCore/GormCore.h>
+
 #include "GormTableViewEditor.h"
 #include "GormNSTableView.h"
-#include <GormCore/GormViewKnobs.h>
 
 NSString *IBTableColumnPboardType = @"IBTableColumnPboardType";
 

--- a/Palettes/3Containers/GormTableViewSizeInspector.h
+++ b/Palettes/3Containers/GormTableViewSizeInspector.h
@@ -25,7 +25,7 @@
 #ifndef INCLUDED_GormTableViewSizeInspector_h
 #define INCLUDED_GormTableViewSizeInspector_h
 
-#include <GormCore/GormViewSizeInspector.h>
+#include <GormCore/GormCore.h>
 
 @interface GormTableViewSizeInspector : GormViewSizeInspector
 @end

--- a/Palettes/3Containers/GormTableViewSizeInspector.m
+++ b/Palettes/3Containers/GormTableViewSizeInspector.m
@@ -22,7 +22,8 @@
    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
 */
 
-#include <AppKit/NSTableView.h>
+#include <AppKit/AppKit.h>
+
 #include "GormTableViewSizeInspector.h"
 
 @implementation GormTableViewSizeInspector

--- a/Palettes/3Containers/inspectors.m
+++ b/Palettes/3Containers/inspectors.m
@@ -25,6 +25,7 @@
 
 #include <Foundation/Foundation.h>
 #include <AppKit/AppKit.h>
+
 #include <InterfaceBuilder/InterfaceBuilder.h>
 
 /**

--- a/Palettes/4Data/.cvsignore
+++ b/Palettes/4Data/.cvsignore
@@ -1,6 +1,0 @@
-*.app
-*.debug
-*.profile
-*.palette
-*obj
-.gdbinit

--- a/Palettes/4Data/DataPalette.m
+++ b/Palettes/4Data/DataPalette.m
@@ -23,20 +23,10 @@
 */
 
 #include <Foundation/Foundation.h>
-#include <Foundation/NSFormatter.h>
-#include <Foundation/NSNotification.h>
-#include <Foundation/NSNumberFormatter.h>
-#include <AppKit/NSComboBox.h>
-#include <AppKit/NSScrollView.h>
-#include <AppKit/NSImage.h>
-#include <AppKit/NSImageView.h>
-#include <AppKit/NSTextContainer.h>
-#include <AppKit/NSTextView.h>
-#include <AppKit/NSWindow.h>
-#include <AppKit/NSClipView.h>
-#include <InterfaceBuilder/IBPalette.h>
-#include <InterfaceBuilder/IBViewResourceDragging.h>
-#include <GormCore/GormPrivate.h>
+#include <AppKit/AppKit.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
+#include <GormCore/GormCore.h>
 
 /* -----------------------------------------------------------
  * Some additions to the NSNumberFormatter Class specific to Gorm

--- a/Palettes/4Data/GormDateFormatterAttributesInspector.m
+++ b/Palettes/4Data/GormDateFormatterAttributesInspector.m
@@ -26,11 +26,10 @@
 
 #include <Foundation/Foundation.h>
 #include <AppKit/AppKit.h>
+
 #include <InterfaceBuilder/InterfaceBuilder.h>
-#include <GormCore/GormPrivate.h>
-#include <GormCore/GormViewEditor.h>
-#include <GormCore/NSColorWell+GormExtensions.h>
-#include <GormCore/GormViewSizeInspector.h>
+#include <GormCore/GormCore.h>
+
 #include "GormDateFormatterAttributesInspector.h"
 
 /* this macro makes sure that the string contains a value, even if @"" */

--- a/Palettes/4Data/GormImageViewAttributesInspector.h
+++ b/Palettes/4Data/GormImageViewAttributesInspector.h
@@ -33,7 +33,7 @@
 #ifndef INCLUDED_GormImageViewAttributesInspector_h
 #define INCLUDED_GormImageViewAttributesInspector_h
 
-#include <InterfaceBuilder/IBInspector.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSButton;
 @class NSMatrix;

--- a/Palettes/4Data/GormImageViewAttributesInspector.m
+++ b/Palettes/4Data/GormImageViewAttributesInspector.m
@@ -30,15 +30,12 @@
   Author : Fabien Vallon <fabien@sonappart.net>
 */
 
+#include <Foundation/Foundation.h>
+#include <AppKit/AppKit.h>
+
+#include <GormCore/GormCore.h>
+
 #include "GormImageViewAttributesInspector.h"
-#include <Foundation/NSNotification.h>
-#include <AppKit/NSButton.h>
-#include <AppKit/NSImage.h>
-#include <AppKit/NSImageView.h>
-#include <AppKit/NSMatrix.h>
-#include <AppKit/NSNibLoading.h>
-#include <AppKit/NSTextField.h>
-#include <GormCore/GormImage.h>
 
 /* This macro makes sure that the string contains a value, even if @"" */
 #define VSTR(str) ({id _str = (id)str; (_str) ? (id)_str : (id)(@"");})

--- a/Palettes/4Data/GormNSComboBoxAttributesInspector.h
+++ b/Palettes/4Data/GormNSComboBoxAttributesInspector.h
@@ -33,7 +33,7 @@
 #ifndef INCLUDED_GormNSComboBoxAttributesInspector_h
 #define INCLUDED_GormNSComboBoxAttributesInspector_h
 
-#include <InterfaceBuilder/IBInspector.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSMutableArray;
 @class NSMatrix;

--- a/Palettes/4Data/GormNSComboBoxAttributesInspector.m
+++ b/Palettes/4Data/GormNSComboBoxAttributesInspector.m
@@ -30,16 +30,11 @@
   Author : Fabien Vallon <fabien@sonappart.net>
 */
 
-#include "GormNSComboBoxAttributesInspector.h"
+#include <AppKit/AppKit.h>
 
-#include <AppKit/NSButton.h>
-#include <GormCore/NSColorWell+GormExtensions.h>
-#include <AppKit/NSComboBox.h>
-#include <AppKit/NSForm.h>
-#include <AppKit/NSMatrix.h>
-#include <AppKit/NSNibLoading.h>
-#include <AppKit/NSTableView.h>
-#include <AppKit/NSTextField.h>
+#include <GormCore/GormCore.h>
+
+#include "GormNSComboBoxAttributesInspector.h"
 
 
 /*

--- a/Palettes/4Data/GormNumberFormatterAttributesInspector.m
+++ b/Palettes/4Data/GormNumberFormatterAttributesInspector.m
@@ -27,10 +27,7 @@
 #include <Foundation/Foundation.h>
 #include <AppKit/AppKit.h>
 
-#include <GormCore/GormPrivate.h>
-#include <GormCore/GormViewEditor.h>
-#include <GormCore/NSColorWell+GormExtensions.h>
-#include <GormCore/GormViewSizeInspector.h>
+#include <GormCore/GormCore.h>
 
 #include "GormNumberFormatterAttributesInspector.h"
 

--- a/Palettes/4Data/GormTextViewAttributesInspector.h
+++ b/Palettes/4Data/GormTextViewAttributesInspector.h
@@ -33,7 +33,7 @@
 #ifndef INCLUDED_GormTextViewAttributesInspector_h
 #define INCLUDED_GormTextViewAttributesInspector_h
 
-#include <InterfaceBuilder/IBInspector.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
 
 @class NSColorWell;
 @class NSMatrix;

--- a/Palettes/4Data/GormTextViewAttributesInspector.m
+++ b/Palettes/4Data/GormTextViewAttributesInspector.m
@@ -30,16 +30,13 @@
   Author : Fabien Vallon <fabien@sonappart.net>
 */
 
+#include <AppKit/AppKit.h>
+
+// #warning GNUstep bug ?
+#include <GormCore/GormCore.h>
+
 #include "GormTextViewAttributesInspector.h"
 
-// #warning GNUstep bug ? 
-#include <GormCore/NSColorWell+GormExtensions.h>
-
-#include <AppKit/NSButton.h>
-#include <AppKit/NSMatrix.h>
-#include <AppKit/NSNibLoading.h>
-#include <AppKit/NSScrollView.h>
-#include <AppKit/NSTextView.h>
 
 @implementation GormTextViewAttributesInspector
 

--- a/Palettes/4Data/GormTextViewEditor.h
+++ b/Palettes/4Data/GormTextViewEditor.h
@@ -27,10 +27,11 @@
 #ifndef INCLUDED_GormTextViewEditor_h
 #define INCLUDED_GormTextViewEditor_h
 
-#include <InterfaceBuilder/InterfaceBuilder.h>
 #include <Foundation/Foundation.h>
 #include <AppKit/AppKit.h>
-#include <GormCore/GormViewEditor.h>
+
+#include <InterfaceBuilder/InterfaceBuilder.h>
+#include <GormCore/GormCore.h>
 
 @interface GormTextViewEditor : GormViewEditor
 {

--- a/Palettes/4Data/GormTextViewEditor.m
+++ b/Palettes/4Data/GormTextViewEditor.m
@@ -26,12 +26,9 @@
 
 #include <Foundation/Foundation.h>
 #include <AppKit/AppKit.h>
-#include <InterfaceBuilder/InterfaceBuilder.h>
 
-#include <GormCore/GormPrivate.h>
-#include <GormCore/GormViewEditor.h>
-#include <GormCore/NSColorWell+GormExtensions.h>
-#include <GormCore/GormViewSizeInspector.h>
+#include <InterfaceBuilder/InterfaceBuilder.h>
+#include <GormCore/GormCore.h>
 
 #include "GormTextViewEditor.h"
 

--- a/Palettes/4Data/GormTextViewSizeInspector.h
+++ b/Palettes/4Data/GormTextViewSizeInspector.h
@@ -28,7 +28,7 @@
 #define INCLUDED_GormTextViewSizeInspector_h
 
 #include <InterfaceBuilder/InterfaceBuilder.h>
-#include <GormCore/GormViewSizeInspector.h>
+#include <GormCore/GormCore.h>
 
 @interface GormTextViewSizeInspector : GormViewSizeInspector
 @end

--- a/Palettes/4Data/inspectors.m
+++ b/Palettes/4Data/inspectors.m
@@ -26,6 +26,7 @@
 
 #include <Foundation/Foundation.h>
 #include <AppKit/AppKit.h>
+
 #include <InterfaceBuilder/InterfaceBuilder.h>
 
 @implementation	NSTextView (IBObjectAdditions)

--- a/Plugins/GModel/GormGModelPlugin.m
+++ b/Plugins/GModel/GormGModelPlugin.m
@@ -1,4 +1,4 @@
-/* GormGModelModule.m
+/* GormGModelPlugin.m
  *
  * Copyright (C) 2007 Free Software Foundation, Inc.
  *
@@ -21,9 +21,10 @@
  * along with this program; if not, write to the Free Software
  */
 
-#include <GormCore/GormPlugin.h>
-#include <GormCore/GormWrapperLoader.h>
-#include <Foundation/NSArray.h>
+#include <Foundation/Foundation.h>
+
+#include <GormCore/GormCore.h>
+
 #include "GormGModelWrapperLoader.h"
 
 @interface GormGModelPlugin : GormPlugin

--- a/Plugins/GModel/GormGModelWrapperLoader.h
+++ b/Plugins/GModel/GormGModelWrapperLoader.h
@@ -25,7 +25,7 @@
 #ifndef GORM_GMODELWRAPPERLOADER
 #define GORM_GMODELWRAPPERLOADER
 
-#include <GormCore/GormWrapperLoader.h>
+#include <GormCore/GormCore.h>
 
 @class NSMutableArray, NSString;
 

--- a/Plugins/GModel/GormGModelWrapperLoader.m
+++ b/Plugins/GModel/GormGModelWrapperLoader.m
@@ -22,17 +22,15 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <AppKit/NSWindow.h>
-#include <AppKit/NSNibConnector.h>
-#include <AppKit/NSFileWrapper.h>
+#include <AppKit/AppKit.h>
+
+#include <GormCore/GormCore.h>
+
 #include <GNUstepGUI/GMArchiver.h>
 #include <GNUstepGUI/IMLoading.h>
 #include <GNUstepGUI/IMCustomObject.h>
 #include <GNUstepGUI/GSDisplayServer.h>
-#include <GormCore/GormPrivate.h>
-#include <GormCore/GormCustomView.h>
-#include <GormCore/GormDocument.h>
-#include <GormCore/GormFunctions.h>
+
 #include "GormGModelWrapperLoader.h"
 
 static Class gmodel_class(NSString *className);

--- a/Plugins/Gorm/GormGormPlugin.m
+++ b/Plugins/Gorm/GormGormPlugin.m
@@ -1,4 +1,4 @@
-/* GormNibModule.m
+/* GormGormPlugin.m
  *
  * Copyright (C) 2007 Free Software Foundation, Inc.
  *
@@ -21,9 +21,10 @@
  * along with this program; if not, write to the Free Software
  */
 
-#include <GormCore/GormPlugin.h>
-#include <GormCore/GormWrapperLoader.h>
-#include <Foundation/NSArray.h>
+#include <Foundation/Foundation.h>
+
+#include <GormCore/GormCore.h>
+
 #include "GormGormWrapperLoader.h"
 
 @interface GormGormPlugin : GormPlugin

--- a/Plugins/Gorm/GormGormWrapperBuilder.m
+++ b/Plugins/Gorm/GormGormWrapperBuilder.m
@@ -26,14 +26,10 @@
 
 #include <Foundation/Foundation.h>
 #include <AppKit/AppKit.h>
+
+#include <GormCore/GormCore.h>
+
 #include <GNUstepGUI/GSGormLoading.h>
-#include <GormCore/GormWrapperBuilder.h>
-#include <GormCore/GormClassManager.h>
-#include <GormCore/GormFilePrefsManager.h>
-#include <GormCore/GormDocument.h>
-#include <GormCore/GormFilesOwner.h>
-#include <GormCore/GormProtocol.h>
-#include <GormCore/GormPalettesManager.h>
 
 @interface GormDocument (BuilderAdditions)
 - (void) prepareConnections;

--- a/Plugins/Gorm/GormGormWrapperLoader.h
+++ b/Plugins/Gorm/GormGormWrapperLoader.h
@@ -25,7 +25,7 @@
 #ifndef GORM_GORMWRAPPERLOADER
 #define GORM_GORMWRAPPERLOADER
 
-#include <GormCore/GormWrapperLoader.h>
+#include <GormCore/GormCore.h>
 
 @class NSMutableArray, NSString;
 

--- a/Plugins/Gorm/GormGormWrapperLoader.m
+++ b/Plugins/Gorm/GormGormWrapperLoader.m
@@ -24,16 +24,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA.
  */
 
-#include <GormCore/GormWrapperLoader.h>
 #include <Foundation/Foundation.h>
 #include <AppKit/AppKit.h>
-#include <GormCore/GormPalettesManager.h>
-#include <GormCore/GormClassManager.h>
-#include <GormCore/GormImage.h>
-#include <GormCore/GormSound.h>
-#include <GormCore/GormPrivate.h>
-#include <GormCore/NSView+GormExtensions.h>
-#include <GormCore/GormFunctions.h>
+
+#include <GormCore/GormCore.h>
 
 @interface GormGormWrapperLoader : GormWrapperLoader
 {

--- a/Plugins/Nib/GormNibPlugin.m
+++ b/Plugins/Nib/GormNibPlugin.m
@@ -21,10 +21,11 @@
  * along with this program; if not, write to the Free Software
  */
 
-#include <GormCore/GormPlugin.h>
-#include <GormCore/GormWrapperLoader.h>
+#include <Foundation/Foundation.h>
+
+#include <GormCore/GormCore.h>
+
 #include "GormNibWrapperLoader.h"
-#include <Foundation/NSArray.h>
 
 @interface GormNibPlugin : GormPlugin
 @end

--- a/Plugins/Nib/GormNibWrapperBuilder.m
+++ b/Plugins/Nib/GormNibWrapperBuilder.m
@@ -26,17 +26,10 @@
 
 #include <Foundation/Foundation.h>
 #include <AppKit/AppKit.h>
-#include <GNUstepGUI/GSNibLoading.h>
 
-#include <GormCore/GormWrapperBuilder.h>
-#include <GormCore/GormClassManager.h>
-#include <GormCore/GormFilePrefsManager.h>
-#include <GormCore/GormDocument.h>
-#include <GormCore/GormProtocol.h>
-#include <GormCore/GormPalettesManager.h>
-#include <GormCore/GormCustomView.h>
-#include <GormCore/GormPrivate.h>
-#include <GormCore/GormFilesOwner.h>
+#include <GormCore/GormCore.h>
+
+#include <GNUstepGUI/GSNibLoading.h>
 
 // allow access to a private category...
 @interface NSIBObjectData (BuilderAdditions)

--- a/Plugins/Nib/GormNibWrapperLoader.h
+++ b/Plugins/Nib/GormNibWrapperLoader.h
@@ -25,8 +25,10 @@
 #ifndef GORM_NIBWRAPPERLOADER
 #define GORM_NIBWRAPPERLOADER
 
-#include <GormCore/GormWrapperLoader.h>
+#include <GormCore/GormCore.h>
+
 #include <GNUstepGUI/GSNibLoading.h>
+
 #include "GormNibCustomResource.h"
 
 @interface GormNibWrapperLoader : GormWrapperLoader

--- a/Plugins/Nib/GormNibWrapperLoader.m
+++ b/Plugins/Nib/GormNibWrapperLoader.m
@@ -25,16 +25,7 @@
 #include <Foundation/Foundation.h>
 #include <AppKit/AppKit.h>
 
-#include <GormCore/GormPalettesManager.h>
-#include <GormCore/GormClassManager.h>
-#include <GormCore/GormImage.h>
-#include <GormCore/GormSound.h>
-#include <GormCore/GormPrivate.h>
-#include <GormCore/NSView+GormExtensions.h>
-#include <GormCore/GormFunctions.h>
-#include <GormCore/GormCustomView.h>
-#include <GormCore/GormWindowTemplate.h>
-#include <GormCore/GormNSWindow.h>
+#include <GormCore/GormCore.h>
 
 #include "GormNibWrapperLoader.h"
 

--- a/Plugins/Xib/GormXibPlugin.m
+++ b/Plugins/Xib/GormXibPlugin.m
@@ -21,10 +21,11 @@
  * along with this program; if not, write to the Free Software
  */
 
-#include <GormCore/GormPlugin.h>
-#include <GormCore/GormWrapperLoader.h>
+#include <Foundation/Foundation.h>
+
+#include <GormCore/GormCore.h>
+
 #include "GormXibWrapperLoader.h"
-#include <Foundation/NSArray.h>
 
 @interface GormXibPlugin : GormPlugin
 @end

--- a/Plugins/Xib/GormXibWrapperLoader.h
+++ b/Plugins/Xib/GormXibWrapperLoader.h
@@ -25,7 +25,8 @@
 #ifndef GORM_NIBWRAPPERLOADER
 #define GORM_NIBWRAPPERLOADER
 
-#include <GormCore/GormWrapperLoader.h>
+#include <GormCore/GormCore.h>
+
 #include <GNUstepGUI/GSXibLoading.h>
 
 @interface GormXibWrapperLoader : GormWrapperLoader

--- a/Plugins/Xib/GormXibWrapperLoader.m
+++ b/Plugins/Xib/GormXibWrapperLoader.m
@@ -25,16 +25,7 @@
 #include <Foundation/Foundation.h>
 #include <AppKit/AppKit.h>
 
-#include <GormCore/GormPalettesManager.h>
-#include <GormCore/GormClassManager.h>
-#include <GormCore/GormImage.h>
-#include <GormCore/GormSound.h>
-#include <GormCore/GormPrivate.h>
-#include <GormCore/NSView+GormExtensions.h>
-#include <GormCore/GormFunctions.h>
-#include <GormCore/GormCustomView.h>
-#include <GormCore/GormWindowTemplate.h>
-#include <GormCore/GormNSWindow.h>
+#include <GormCore/GormCore.h>
 
 #include "GormXibWrapperLoader.h"
 


### PR DESCRIPTION
use umbrella headers when using headers from other subprojects (to make PCH easier in the future); umbrella headers created for GormCore, GormObjCHeaderParser, GormPrefs; GNUmakefiles updated accordingly; some stray .cvsignore files deleted