### PR TITLE
Make Inspector's shortcuts available globally again

### DIFF
--- a/Applications/Gorm/GormAppDelegate.m
+++ b/Applications/Gorm/GormAppDelegate.m
@@ -23,6 +23,7 @@
  * USA.
  */
 
+#include "AppKit/NSApplication.h"
 #import <Foundation/NSArray.h>
 #import <Foundation/NSDictionary.h>
 #import <Foundation/NSSet.h>
@@ -32,6 +33,28 @@
 
 #import "GormAppDelegate.h"
 #import "GormLanguageViewController.h"
+
+@interface Gorm : NSApplication
+@end
+@implementation Gorm
+
+/*
+   NSApplication override to make Inspector's shortcuts available globally
+*/
+- (void) sendEvent: (NSEvent *)theEvent
+{
+  if ([theEvent type] == NSKeyDown)
+    {
+      NSPanel *inspector = [[_delegate inspectorsManager] panel];
+      if ([inspector performKeyEquivalent: theEvent] != NO)
+        {
+          [inspector orderFront: self];
+          return;
+        }
+    }
+  [super sendEvent: theEvent];
+}
+@end
 
 @interface GormDocument (Private)
 

--- a/Applications/Gorm/GormAppDelegate.m
+++ b/Applications/Gorm/GormAppDelegate.m
@@ -23,7 +23,6 @@
  * USA.
  */
 
-#include "AppKit/NSApplication.h"
 #import <Foundation/NSArray.h>
 #import <Foundation/NSDictionary.h>
 #import <Foundation/NSSet.h>

--- a/Applications/Gorm/GormInfo.plist
+++ b/Applications/Gorm/GormInfo.plist
@@ -1,7 +1,7 @@
 {
     NSIcon = "Gorm.tiff";
     NSMainNibFile = "Gorm.gorm";
-    NSPrincipalClass = "NSApplication";
+    NSPrincipalClass = "Gorm";
     NSRole = "Editor";
     
     NSTypes = (


### PR DESCRIPTION
It was broken after refactoring some times ago.